### PR TITLE
회원 가입 유효성 및 중복 이메일 확인

### DIFF
--- a/backend/src/main/java/com/ourdressingtable/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ourdressingtable/exception/ErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 회원 가입 관련
-    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "M001", "이미 가입된 사용자입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "M001", "이미 가입된 이메일입니다."),
     INVALID_MEMBER(HttpStatus.BAD_REQUEST, "M002", "유효하지 않은 사용자입니다."),
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "M003", "사용자를 찾을 수 없습니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "M004", "유효하지 않은 이메일 형식입니다."),

--- a/backend/src/main/java/com/ourdressingtable/member/dto/CreateMemberRequest.java
+++ b/backend/src/main/java/com/ourdressingtable/member/dto/CreateMemberRequest.java
@@ -25,10 +25,11 @@ public class CreateMemberRequest {
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
+    // TODO: CUSTOM ANNOTATION 생성 후 처리 하기
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Size(min = 8, max = 20, message = "비밀번호는 8~20자 사이여야 합니다.")
-    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$)",
-            message = "비밀번호는 알파벳 대/소문자, 숫자, 특수문자를 포함해야 합니다.")
+//    @Size(min = 8, max = 20, message = "비밀번호는 8~20자 사이여야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+            message = "비밀번호는 알파벳 대/소문자, 숫자, 특수문자가 포함한 8자~20자 사이여야 합니다.")
     private String password;
 
     @NotBlank(message = "이름을 입력해주세요.")

--- a/backend/src/main/java/com/ourdressingtable/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/ourdressingtable/member/repository/MemberRepository.java
@@ -4,5 +4,5 @@ import com.ourdressingtable.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    boolean existsByEmail(String email);
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
@@ -1,5 +1,7 @@
 package com.ourdressingtable.member.service.impl;
 
+import com.ourdressingtable.exception.ErrorCode;
+import com.ourdressingtable.exception.OurDressingTableException;
 import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.repository.MemberRepository;
@@ -18,6 +20,12 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public Long createMember(CreateMemberRequest createMemberRequest) {
+        boolean isExists = memberRepository.existsByEmail(createMemberRequest.getEmail());
+
+        if(isExists) {
+            throw new OurDressingTableException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
         Member member = memberRepository.save(createMemberRequest.toEntity());
         return member.getId();
     }

--- a/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
@@ -41,7 +41,7 @@ public class MemberControllerTest {
         // given
         CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
                 .email("member1@gmail.com")
-                .password("password")
+                .password("Password1234!!")
                 .name("member1")
                 .nickname("me")
                 .phoneNumber("010-1234-5678")

--- a/backend/src/test/java/com/ourdressingtable/member/service/MemberServiceImplTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/service/MemberServiceImplTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.ourdressingtable.exception.ErrorCode;
+import com.ourdressingtable.exception.OurDressingTableException;
 import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.domain.Role;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
@@ -62,5 +64,26 @@ public class MemberServiceImplTest {
 
         }
 
+        @DisplayName("회원 가입 실패_중복 이메일")
+        @Test
+        void createMember_Fail_DuplicateEmail() {
+            // given
+            CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
+                    .email("member1@gmail.com")
+                    .password("Password123!")
+                    .name("member1")
+                    .nickname("me")
+                    .phoneNumber("010-1234-5678")
+                    .role(Role.ROLE_MEMBER)
+                    .build();
+
+            when(memberRepository.existsByEmail(createMemberRequest.getEmail())).thenReturn(true);
+
+            // when & then
+            OurDressingTableException ourDressingTableException = assertThrows(OurDressingTableException.class, () -> memberServiceImpl.createMember(createMemberRequest));
+            assertEquals(ourDressingTableException.getHttpStatus(), ErrorCode.EMAIL_ALREADY_EXISTS.getHttpStatus());
+            assertEquals(ourDressingTableException.getMessage(), ErrorCode.EMAIL_ALREADY_EXISTS.getMessage());
+
+        }
     }
 }

--- a/backend/src/test/java/com/ourdressingtable/member/service/MemberServiceImplTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/service/MemberServiceImplTest.java
@@ -1,0 +1,66 @@
+package com.ourdressingtable.member.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.member.domain.Role;
+import com.ourdressingtable.member.dto.CreateMemberRequest;
+import com.ourdressingtable.member.repository.MemberRepository;
+import com.ourdressingtable.member.service.impl.MemberServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class MemberServiceImplTest {
+
+    @InjectMocks
+    private MemberServiceImpl memberServiceImpl;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("회원 가입 테스트")
+    class singUp {
+        @DisplayName("회원 가입 성공")
+        @Test
+        void createMember_Success() {
+            // given
+            CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
+                    .email("member1@gmail.com")
+                    .password("Password123!")
+                    .name("member1")
+                    .nickname("me")
+                    .phoneNumber("010-1234-5678")
+                    .role(Role.ROLE_MEMBER)
+                    .build();
+
+            Member member = createMemberRequest.toEntity();
+            ReflectionTestUtils.setField(member,"id",1L);
+            when(memberRepository.save(any(Member.class))).thenReturn(member);
+
+            // when
+            Long savedId = memberServiceImpl.createMember(createMemberRequest);
+
+            //then
+            assertNotNull(savedId);
+            assertEquals(createMemberRequest.getEmail(), member.getEmail());
+
+        }
+
+    }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
- #8 : 회원 가입 유효성 및 중복 이메일 확인

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 회원 가입 시 필드값 유효성 확인
- 중복 이메일 확인
- 위 사항 예외 처리 추가

### 🧪테스트 여부
- [x]  테스트 코드
- [x]  API 코드