### PR TITLE
탈퇴 회원 생성 기능 추가

### DIFF
--- a/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
@@ -5,6 +5,8 @@ import com.ourdressingtable.member.dto.CreateMemberResponse;
 import com.ourdressingtable.member.dto.MemberResponse;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
+import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
+import com.ourdressingtable.member.dto.WithdrawalMemberResponse;
 import com.ourdressingtable.member.service.MemberService;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -12,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.sql.Update;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -46,7 +49,7 @@ public class MemberController {
                 .build();
 
         Long id = memberService.createMember(createMemberRequest);
-        return ResponseEntity.created(URI.create("/api/member/" + id))
+        return ResponseEntity.created(URI.create("/api/members/" + id))
                 .body(new CreateMemberResponse(id));
     }
 
@@ -62,6 +65,21 @@ public class MemberController {
     public ResponseEntity updateMember(@PathVariable("userId") Long userId, @RequestBody @Valid UpdateMemberRequest updateMemberRequest) {
         memberService.updateMember(userId, updateMemberRequest);
         return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity deleteMember(@PathVariable("userId") Long userId) {
+        memberService.deleteMember(userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 탈퇴 회원 관리
+    @PostMapping("/withdrawal/{userId}")
+    public ResponseEntity<WithdrawalMemberResponse> withdrawMember(@PathVariable("userId") Long userId, @RequestBody @Valid WithdrawalMemberRequest withdrawalMemberRequest) {
+        Long id = memberService.createWithdrawMember(userId, withdrawalMemberRequest);
+
+        return ResponseEntity.created(URI.create("/api/withdrawalMembers/" + id))
+                .body(new WithdrawalMemberResponse(id));
     }
 
 }

--- a/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
@@ -2,14 +2,18 @@ package com.ourdressingtable.member.controller;
 
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.CreateMemberResponse;
+import com.ourdressingtable.member.dto.MemberResponse;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
+import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.member.service.MemberService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.sql.Update;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -52,6 +56,12 @@ public class MemberController {
         OtherMemberResponse otherMemberResponse = memberService.getMember(userId);
         return ResponseEntity.ok(otherMemberResponse);
 
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity updateMember(@PathVariable("userId") Long userId, @RequestBody @Valid UpdateMemberRequest updateMemberRequest) {
+        memberService.updateMember(userId, updateMemberRequest);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/backend/src/main/java/com/ourdressingtable/member/domain/Member.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.ourdressingtable.member.domain;
 
 
+import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.util.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -76,5 +77,23 @@ public class Member extends BaseTimeEntity {
         this.lockedCount = lockedCount;
         this.imageUrl = imageUrl;
 
+    }
+
+    public void updateMember(UpdateMemberRequest updateMemberRequest) {
+        this.password = getOrDefault(updateMemberRequest.getPassword(),this.password);
+        this.nickname = getOrDefault(updateMemberRequest.getNickname(),this.nickname);
+        this.phoneNumber = getOrDefault(updateMemberRequest.getPhoneNumber(),this.phoneNumber);
+        this.skinType = getOrDefault(updateMemberRequest.getSkinType(),this.skinType);
+        this.colorType = getOrDefault(updateMemberRequest.getColorType(),this.colorType);
+        this.birthDate = getOrDefault(updateMemberRequest.getBirthDate(),this.birthDate);
+        this.imageUrl = getOrDefault(updateMemberRequest.getImageUrl(),this.imageUrl);
+    }
+
+    private String getOrDefault(String newValue, String currentValue) {
+        return (newValue == null || newValue.isBlank()) ? currentValue : newValue;
+    }
+
+    private <T> T getOrDefault(T newValue, T currentValue) {
+        return (newValue != null) ? newValue : currentValue;
     }
 }

--- a/backend/src/main/java/com/ourdressingtable/member/domain/Member.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/Member.java
@@ -1,8 +1,12 @@
 package com.ourdressingtable.member.domain;
 
 
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.util.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,6 +14,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.Date;
 import lombok.AccessLevel;
@@ -60,6 +66,11 @@ public class Member extends BaseTimeEntity {
 
     private String imageUrl;
 
+
+    @JsonIgnore
+    @OneToOne(mappedBy = "member")
+    private WithdrawalMember withdrawalMember;
+
     @Builder
     public Member(Long id, String email, String password, String name, String nickname, String phoneNumber, Role role, SkinType skinType, ColorType colorType, Date birthDate, AuthType authType, Status status, int lockedCount, String imageUrl) {
         this.id = id;
@@ -87,6 +98,10 @@ public class Member extends BaseTimeEntity {
         this.colorType = getOrDefault(updateMemberRequest.getColorType(),this.colorType);
         this.birthDate = getOrDefault(updateMemberRequest.getBirthDate(),this.birthDate);
         this.imageUrl = getOrDefault(updateMemberRequest.getImageUrl(),this.imageUrl);
+    }
+
+    public void changeMemberStatus() {
+        this.status = Status.WITHDRAWAL;
     }
 
     private String getOrDefault(String newValue, String currentValue) {

--- a/backend/src/main/java/com/ourdressingtable/member/domain/Status.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/Status.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum Status {
     ACTIVATE(0, "활성화", "활성화 중인 계정"),
     LOCK(1, "일시 중지", "일시 중지 중인 계정"),
-    BLOCK(2, "영구 중지", "영구 중지 중인 계정");
+    BLOCK(2, "영구 중지", "영구 중지 중인 계정"),
+    WITHDRAWAL(3, "탈퇴", "탈퇴한 계정");
 
     private final int code;
     private final String name;

--- a/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
@@ -1,0 +1,49 @@
+package com.ourdressingtable.member.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.ourdressingtable.util.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "withdrawal_members")
+public class WithdrawalMember extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String reason;
+
+    @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public WithdrawalMember(Long id, String reason, Member member) {
+        this.id = id;
+        this.reason = reason;
+        this.member = member;
+
+    }
+
+
+
+}

--- a/backend/src/main/java/com/ourdressingtable/member/dto/UpdateMemberRequest.java
+++ b/backend/src/main/java/com/ourdressingtable/member/dto/UpdateMemberRequest.java
@@ -1,0 +1,59 @@
+package com.ourdressingtable.member.dto;
+
+import com.ourdressingtable.member.domain.ColorType;
+import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.member.domain.SkinType;
+import jakarta.validation.constraints.Pattern;
+import java.util.Date;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateMemberRequest {
+
+    // TODO: Passay or CUSTOM ANNOTATION 생성 후 처리 하기
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+            message = "비밀번호는 알파벳 대/소문자, 숫자, 특수문자가 포함한 8자~20자 사이여야 합니다.")
+    private String password;
+
+    private String nickname;
+
+    private String phoneNumber;
+
+    private SkinType skinType;
+
+    private ColorType colorType;
+
+    private Date birthDate;
+
+    private String imageUrl;
+
+    @Builder
+    public UpdateMemberRequest(String password, String nickname, String phoneNumber, SkinType skinType, ColorType colorType, Date birthDate, String imageUrl) {
+        this.password = password;
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.skinType = skinType;
+        this.colorType = colorType;
+        this.birthDate = birthDate;
+        this.imageUrl = imageUrl;
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .password(password)
+                .nickname(nickname)
+                .phoneNumber(phoneNumber)
+                .skinType(skinType)
+                .colorType(colorType)
+                .birthDate(birthDate)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/ourdressingtable/member/dto/WithdrawalMemberRequest.java
+++ b/backend/src/main/java/com/ourdressingtable/member/dto/WithdrawalMemberRequest.java
@@ -1,0 +1,31 @@
+package com.ourdressingtable.member.dto;
+
+import com.ourdressingtable.member.domain.WithdrawalMember;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawalMemberRequest {
+
+    @NotBlank
+    private String reason;
+
+    @Builder
+    public WithdrawalMemberRequest(String reason) {
+        this.reason = reason;
+    }
+
+    public WithdrawalMember toEntity() {
+        return WithdrawalMember.builder()
+                .reason(reason)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/ourdressingtable/member/dto/WithdrawalMemberResponse.java
+++ b/backend/src/main/java/com/ourdressingtable/member/dto/WithdrawalMemberResponse.java
@@ -1,0 +1,19 @@
+package com.ourdressingtable.member.dto;
+
+import com.ourdressingtable.member.domain.WithdrawalMember;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawalMemberResponse {
+
+    private Long id;
+}

--- a/backend/src/main/java/com/ourdressingtable/member/repository/WithdrawalMemberRepository.java
+++ b/backend/src/main/java/com/ourdressingtable/member/repository/WithdrawalMemberRepository.java
@@ -1,0 +1,8 @@
+package com.ourdressingtable.member.repository;
+
+import com.ourdressingtable.member.domain.WithdrawalMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawalMemberRepository extends JpaRepository<WithdrawalMember, Long> {
+
+}

--- a/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
@@ -4,10 +4,12 @@ import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.MemberResponse;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
+import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
 
 public interface MemberService {
     Long createMember(CreateMemberRequest createMemberRequest);
     OtherMemberResponse getMember(Long id);
     void updateMember(Long id, UpdateMemberRequest updateMemberRequest);
-
+    void deleteMember(Long id);
+    Long createWithdrawMember(Long userId, WithdrawalMemberRequest withdrawalMemberRequest);
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
@@ -1,10 +1,13 @@
 package com.ourdressingtable.member.service;
 
 import com.ourdressingtable.member.dto.CreateMemberRequest;
+import com.ourdressingtable.member.dto.MemberResponse;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
+import com.ourdressingtable.member.dto.UpdateMemberRequest;
 
 public interface MemberService {
     Long createMember(CreateMemberRequest createMemberRequest);
     OtherMemberResponse getMember(Long id);
+    void updateMember(Long id, UpdateMemberRequest updateMemberRequest);
 
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
@@ -5,12 +5,14 @@ import com.ourdressingtable.exception.OurDressingTableException;
 import com.ourdressingtable.member.domain.ColorType;
 import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.domain.SkinType;
+import com.ourdressingtable.member.domain.WithdrawalMember;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
+import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
 import com.ourdressingtable.member.repository.MemberRepository;
+import com.ourdressingtable.member.repository.WithdrawalMemberRepository;
 import com.ourdressingtable.member.service.MemberService;
-import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final WithdrawalMemberRepository withdrawalMemberRepository;
 
     @Override
     @Transactional
@@ -46,5 +49,23 @@ public class MemberServiceImpl implements MemberService {
     public void updateMember(Long id, UpdateMemberRequest updateMemberRequest) {
         Member member = memberRepository.findById(id).orElseThrow(()->new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
         member.updateMember(updateMemberRequest);
+    }
+
+    @Override
+    @Transactional
+    public void deleteMember(Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
+        memberRepository.delete(member);
+    }
+
+    @Override
+    @Transactional
+    public Long createWithdrawMember(Long id, WithdrawalMemberRequest withdrawalMemberRequest) {
+        Member member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
+        member.changeMemberStatus();
+
+        WithdrawalMember withdrawalMember = withdrawalMemberRepository.save(withdrawalMemberRequest.toEntity());
+        return withdrawalMember.getId();
+
     }
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
@@ -2,11 +2,15 @@ package com.ourdressingtable.member.service.impl;
 
 import com.ourdressingtable.exception.ErrorCode;
 import com.ourdressingtable.exception.OurDressingTableException;
+import com.ourdressingtable.member.domain.ColorType;
 import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.member.domain.SkinType;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
+import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.member.repository.MemberRepository;
 import com.ourdressingtable.member.service.MemberService;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +28,7 @@ public class MemberServiceImpl implements MemberService {
         boolean isExists = memberRepository.existsByEmail(createMemberRequest.getEmail());
 
         if (isExists) {
-            throw new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND);
+            throw new OurDressingTableException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
         Member member = memberRepository.save(createMemberRequest.toEntity());
@@ -35,5 +39,12 @@ public class MemberServiceImpl implements MemberService {
     public OtherMemberResponse getMember(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
         return OtherMemberResponse.fromEntity(member);
+    }
+
+    @Override
+    @Transactional
+    public void updateMember(Long id, UpdateMemberRequest updateMemberRequest) {
+        Member member = memberRepository.findById(id).orElseThrow(()->new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
+        member.updateMember(updateMemberRequest);
     }
 }

--- a/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
@@ -137,6 +137,6 @@ public class MemberControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.patch("/api/members/{id}", memberId)
                 .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateMemberRequest)))
                 .andExpect(status().isNoContent()).andDo(print());
-    }
+    };
 
 }

--- a/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ourdressingtable.exception.ErrorCode;
+import com.ourdressingtable.exception.OurDressingTableException;
 import com.ourdressingtable.member.domain.Role;
 import com.ourdressingtable.member.domain.SkinType;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
@@ -100,5 +102,19 @@ public class MemberControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.get("/api/members/1")).andExpect(status().isOk()).andDo(print());
 
     }
+
+    @DisplayName("다른 회원 정보 조회 - 실패")
+    @Test
+    public void getOtherMember_shouldReturnError() throws Exception {
+        // given
+        Long memberId = 99L;
+        when(memberService.getMember(memberId)).thenThrow(new OurDressingTableException(
+                ErrorCode.MEMBER_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/members/{id}", memberId).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound()).andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+    }
+
+
 
 }

--- a/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
@@ -1,12 +1,15 @@
 package com.ourdressingtable.member.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.will;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.BDDMockito.willThrow;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ourdressingtable.exception.ErrorCode;
@@ -15,6 +18,7 @@ import com.ourdressingtable.member.domain.Role;
 import com.ourdressingtable.member.domain.SkinType;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
+import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -112,9 +116,27 @@ public class MemberControllerTest {
                 ErrorCode.MEMBER_NOT_FOUND));
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/members/{id}", memberId).contentType(MediaType.APPLICATION_JSON)).andExpect(status().isNotFound()).andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/members/{id}", memberId).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound()).andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
     }
 
+    @DisplayName("회원 정보 수정 - 성공")
+    @Test
+    public void updateMember_shouldReturnSuccess() throws Exception {
+        // given
+        Long memberId = 1L;
+        UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                .nickname("new me")
+                .phoneNumber("010-1234-5678")
+                .build();
 
+        // when
+        doNothing().when(memberService).updateMember(memberId,updateMemberRequest);
+
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/members/{id}", memberId)
+                .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateMemberRequest)))
+                .andExpect(status().isNoContent()).andDo(print());
+    }
 
 }

--- a/backend/src/test/java/com/ourdressingtable/member/service/MemberServiceImplTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/service/MemberServiceImplTest.java
@@ -13,6 +13,7 @@ import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.domain.Role;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
+import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.member.repository.MemberRepository;
 import com.ourdressingtable.member.service.impl.MemberServiceImpl;
 import java.util.Optional;
@@ -96,7 +97,7 @@ public class MemberServiceImplTest {
 
         @DisplayName("회원 조회 성공 테스트")
         @Test
-        public void findUser_ShouldReturnSuccess() {
+        public void findMember_ShouldReturnSuccess() {
             // given
             Member member = Member.builder()
                     .id(1L)
@@ -120,7 +121,7 @@ public class MemberServiceImplTest {
 
         @DisplayName("회원 조회 실패 테스트 - USER NOT FOUND")
         @Test
-        public void findUser_ShouldReturnUserNotFoundError() {
+        public void findMember_ShouldReturnUserNotFoundError() {
             // given
             Member member = Member.builder()
                     .id(1L)
@@ -135,6 +136,60 @@ public class MemberServiceImplTest {
 
             // when
             OurDressingTableException exception = assertThrows(OurDressingTableException.class, () -> memberServiceImpl.getMember(member.getId()));
+
+            //then
+            assertEquals(exception.getHttpStatus(), ErrorCode.MEMBER_NOT_FOUND.getHttpStatus());
+
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 정보 수정 테스트")
+    class updateUser {
+
+        @DisplayName("회원 정보 수정 성공 테스트")
+        @Test
+        public void updateMember_ShouldReturnSuccess() {
+            // given
+            Member member = Member.builder()
+                    .id(1L)
+                    .email("member1@gmail.com")
+                    .password("Password123!")
+                    .name("member1")
+                    .nickname("me")
+                    .phoneNumber("010-1234-5678")
+                    .role(Role.ROLE_MEMBER)
+                    .build();
+
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                    .nickname("new me")
+                    .build();
+
+            when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+
+            // when
+            memberServiceImpl.updateMember(member.getId(),updateMemberRequest);
+
+            //then
+            assertEquals(member.getNickname(),"new me");
+
+
+        }
+
+        @DisplayName("회원 조회 실패 테스트 - USER NOT FOUND")
+        @Test
+        public void updateMember_ShouldReturnUserNotFoundError() {
+            // given
+            Long memberId = 9999L;
+
+            UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                    .nickname("new me")
+                    .build();
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+            // when
+            OurDressingTableException exception = assertThrows(OurDressingTableException.class, () -> memberServiceImpl.updateMember(memberId,updateMemberRequest));
 
             //then
             assertEquals(exception.getHttpStatus(), ErrorCode.MEMBER_NOT_FOUND.getHttpStatus());


### PR DESCRIPTION
### #️⃣연관된 이슈
#8 : 탈퇴 회원  생성

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 회원이 탈퇴하면 회원 정보가 바로 삭제되지않고, 회원 상태가 탈퇴로 바뀌고 탈퇴 회원 테이블에 저장

### 🧪테스트 여부

- [ ]  테스트 코드
- [x]  API 코드

### 🔧 앞으로의 과제
- 탈퇴 회원 생성 테스트 코드 작성