### PR TITLE
Member

### DIFF
--- a/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
@@ -68,18 +68,8 @@ public class MemberController {
     }
 
     @DeleteMapping("/{userId}")
-    public ResponseEntity deleteMember(@PathVariable("userId") Long userId) {
-        memberService.deleteMember(userId);
+    public ResponseEntity deleteMember(@PathVariable("userId") Long userId, @RequestBody @Valid WithdrawalMemberRequest withdrawalMemberRequest) {
+        memberService.deleteMember(userId, withdrawalMemberRequest);
         return ResponseEntity.noContent().build();
     }
-
-    // 탈퇴 회원 관리
-    @PostMapping("/withdrawal/{userId}")
-    public ResponseEntity<WithdrawalMemberResponse> withdrawMember(@PathVariable("userId") Long userId, @RequestBody @Valid WithdrawalMemberRequest withdrawalMemberRequest) {
-        Long id = memberService.createWithdrawMember(userId, withdrawalMemberRequest);
-
-        return ResponseEntity.created(URI.create("/api/withdrawalMembers/" + id))
-                .body(new WithdrawalMemberResponse(id));
-    }
-
 }

--- a/backend/src/main/java/com/ourdressingtable/member/domain/Member.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/Member.java
@@ -66,11 +66,6 @@ public class Member extends BaseTimeEntity {
 
     private String imageUrl;
 
-
-    @JsonIgnore
-    @OneToOne(mappedBy = "member")
-    private WithdrawalMember withdrawalMember;
-
     @Builder
     public Member(Long id, String email, String password, String name, String nickname, String phoneNumber, Role role, SkinType skinType, ColorType colorType, Date birthDate, AuthType authType, Status status, int lockedCount, String imageUrl) {
         this.id = id;
@@ -98,10 +93,6 @@ public class Member extends BaseTimeEntity {
         this.colorType = getOrDefault(updateMemberRequest.getColorType(),this.colorType);
         this.birthDate = getOrDefault(updateMemberRequest.getBirthDate(),this.birthDate);
         this.imageUrl = getOrDefault(updateMemberRequest.getImageUrl(),this.imageUrl);
-    }
-
-    public void changeMemberStatus() {
-        this.status = Status.WITHDRAWAL;
     }
 
     private String getOrDefault(String newValue, String currentValue) {

--- a/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
@@ -1,20 +1,15 @@
 package com.ourdressingtable.member.domain;
 
-import static jakarta.persistence.FetchType.LAZY;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.ourdressingtable.util.BaseTimeEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,33 +20,40 @@ import org.springframework.data.annotation.CreatedDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "withdrawal_members")
-public class WithdrawalMember extends BaseTimeEntity {
+public class WithdrawalMember {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String email_hashed;
+    private String hashedEmail;
 
-    private String email_masked;
+    private String maskedEmail;
 
-    private String phone_hashed;
+    private String hashedPhone;
 
-    private String phone_masked;
+    private String maskedPhone;
 
     private String reason;
 
-    private boolean is_blacklisted;
+    private boolean isBlock;
+
+    @Column(name = "withdrew_at")
+    private Timestamp withdrewAt;
 
     @Builder
-    public WithdrawalMember(String email_hashed, String email_masked, String phone_hashed, String phone_masked, String reason, boolean is_blacklisted) {
-        this.email_hashed = email_hashed;
-        this.email_masked = email_masked;
-        this.phone_hashed = phone_hashed;
-        this.phone_masked = phone_masked;
+    public WithdrawalMember(String hashedEmail, String maskedEmail, String hashedPhone, String maskedPhone, String reason, boolean isBlock) {
+        this.hashedEmail = hashedEmail;
+        this.maskedEmail = maskedEmail;
+        this.hashedPhone = hashedPhone;
+        this.maskedPhone = maskedPhone;
         this.reason = reason;
-        this.is_blacklisted = is_blacklisted;
+        this.isBlock = isBlock;
     }
 
+    @PrePersist
+    public void prePersist() {
+        this.withdrewAt = Timestamp.valueOf(LocalDateTime.now());
+    }
 
 
 }

--- a/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
@@ -30,18 +30,26 @@ public class WithdrawalMember extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String email_hashed;
+
+    private String email_masked;
+
+    private String phone_hashed;
+
+    private String phone_masked;
+
     private String reason;
 
-    @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    private boolean is_blacklisted;
 
     @Builder
-    public WithdrawalMember(Long id, String reason, Member member) {
-        this.id = id;
+    public WithdrawalMember(String email_hashed, String email_masked, String phone_hashed, String phone_masked, String reason, boolean is_blacklisted) {
+        this.email_hashed = email_hashed;
+        this.email_masked = email_masked;
+        this.phone_hashed = phone_hashed;
+        this.phone_masked = phone_masked;
         this.reason = reason;
-        this.member = member;
-
+        this.is_blacklisted = is_blacklisted;
     }
 
 

--- a/backend/src/main/java/com/ourdressingtable/member/dto/WithdrawalMemberRequest.java
+++ b/backend/src/main/java/com/ourdressingtable/member/dto/WithdrawalMemberRequest.java
@@ -17,15 +17,21 @@ public class WithdrawalMemberRequest {
 
     @NotBlank
     private String reason;
+    private boolean isBlock;
 
     @Builder
-    public WithdrawalMemberRequest(String reason) {
+    public WithdrawalMemberRequest(String reason, String email, String phone, boolean isBlock) {
         this.reason = reason;
     }
 
-    public WithdrawalMember toEntity() {
+    public WithdrawalMember toEntity(String maskedEmail, String hashedEmail, String maskedPhone, String hashedPhone, boolean isBlock) {
         return WithdrawalMember.builder()
                 .reason(reason)
+                .hashedEmail(hashedEmail)
+                .maskedEmail(maskedEmail)
+                .maskedPhone(maskedPhone)
+                .hashedPhone(hashedPhone)
+                .isBlock(isBlock)
                 .build();
     }
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.ourdressingtable.member.service;
 
+import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.MemberResponse;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
@@ -10,6 +11,6 @@ public interface MemberService {
     Long createMember(CreateMemberRequest createMemberRequest);
     OtherMemberResponse getMember(Long id);
     void updateMember(Long id, UpdateMemberRequest updateMemberRequest);
-    void deleteMember(Long id);
-    Long createWithdrawMember(Long userId, WithdrawalMemberRequest withdrawalMemberRequest);
+    void deleteMember(Long id, WithdrawalMemberRequest withdrawalMemberRequest );
+    Long createWithdrawalMember(WithdrawalMemberRequest withdrawalMemberRequest, Member member);
 }

--- a/backend/src/main/java/com/ourdressingtable/util/HashUtil.java
+++ b/backend/src/main/java/com/ourdressingtable/util/HashUtil.java
@@ -1,0 +1,28 @@
+package com.ourdressingtable.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class HashUtil {
+
+    public static String hash(String input) {
+        try{
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hexString = new StringBuilder();
+            for(byte b : hash){
+                String hex = Integer.toHexString(0xff & b);
+                if(hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("암호화 오류", e);
+        }
+    }
+
+}

--- a/backend/src/main/java/com/ourdressingtable/util/MaskingUtil.java
+++ b/backend/src/main/java/com/ourdressingtable/util/MaskingUtil.java
@@ -1,0 +1,23 @@
+package com.ourdressingtable.util;
+
+public class MaskingUtil {
+
+    public static String maskedEmail(String email) {
+        String[] parts = email.split("@");
+        String namePart = parts[0];
+        String domainPart = parts[1];
+
+        String maskedName = namePart.charAt(0) + "." + namePart.charAt(0) + "***";
+
+        String[] domainParts = domainPart.split("\\.");
+        String maskedDomain = domainParts[0].charAt(0)+"*****";
+
+        return maskedName + "@" + maskedDomain + "." + domainParts[1];
+
+    }
+
+    public static String maskedPhone(String phone) {
+        return phone.replaceAll("(\\d{3})-\\d{4}-(\\d{4})", "$1****$2");
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#8: 회원 탈퇴 프로세스 변경

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 회원이 탈퇴를 신청하면, 탈퇴 회원 테이블에 탈퇴 회원 생성 후,  회원 정보가 삭제

### 🧪테스트 여부

- [ ]  테스트 코드
- [ ]  API 코드

### 🔧 앞으로의 과제
- 회원 탈퇴 테스트 진행