### PR TITLE
Swagger에 Security 적용 및 탈퇴 회원 로직 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	testImplementation ('org.springframework.boot:spring-boot-starter-test'){
 		runtimeOnly 'com.h2database:h2'
 	}
-//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'ch.qos.logback:logback-classic:1.5.6'
 	implementation 'ch.qos.logback:logback-core:1.5.6'

--- a/backend/src/main/java/com/ourdressingtable/common/config/DummyDataInitializer.java
+++ b/backend/src/main/java/com/ourdressingtable/common/config/DummyDataInitializer.java
@@ -1,0 +1,90 @@
+package com.ourdressingtable.common.config;
+
+import com.ourdressingtable.community.comment.domain.Comment;
+import com.ourdressingtable.community.comment.repository.CommentRepository;
+import com.ourdressingtable.community.post.domain.Post;
+import com.ourdressingtable.community.post.repository.PostRepository;
+import com.ourdressingtable.communityCategory.domain.CommunityCategory;
+import com.ourdressingtable.communityCategory.repository.CommunityCategoryRepository;
+import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.member.domain.Role;
+import com.ourdressingtable.member.domain.Status;
+import com.ourdressingtable.member.repository.MemberRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Profile("local")
+public class DummyDataInitializer implements CommandLineRunner {
+
+    private final MemberRepository memberRepository;
+    private final CommunityCategoryRepository communityCategoryRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void run(String... args) throws Exception {
+        // Member 생성
+        String encodedPw = passwordEncoder.encode("Password123!@@@@@@@?");
+        Member member = Member.builder()
+                .email("sample@gmail.com")
+                .password(encodedPw)
+                .name("김이름")
+                .role(Role.ROLE_BASIC)
+                .status(Status.ACTIVATE)
+                .build();
+        memberRepository.save(member);
+
+        // Category 생성
+        CommunityCategory free = CommunityCategory.builder()
+                .name("자유게시판")
+                .build();
+        CommunityCategory qna = CommunityCategory.builder()
+                .name("질문")
+                .build();
+
+        List<CommunityCategory> categories = List.of(free, qna);
+
+        communityCategoryRepository.saveAll(categories);
+
+        // Post 생성
+        Post freePost = Post.builder()
+                .title("안녕하세요!")
+                .content("첫 번째 게시글입니다.")
+                .member(member)
+                .communityCategory(free)
+                .build();
+
+        Post qnaPost = Post.builder()
+                .title("질문이 있어요")
+                .content("게시글 등록은 어떻게 하나요?")
+                .member(member)
+                .communityCategory(qna)
+                .build();
+        postRepository.saveAll(List.of(freePost, qnaPost));
+
+        // Comment 생성
+        Comment comment1 = Comment.builder()
+                .content("환영합니다~")
+                .post(freePost)
+                .member(member)
+                .build();
+
+        Comment comment2 = Comment.builder()
+                .content("저도 궁금해요!")
+                .post(qnaPost)
+                .member(member)
+                .build();
+
+        commentRepository.saveAll(List.of(comment1, comment2));
+    }
+
+}

--- a/backend/src/main/java/com/ourdressingtable/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ourdressingtable/common/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/members/signup").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/ourdressingtable/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/ourdressingtable/common/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.ourdressingtable.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,10 +13,19 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        final String securityScheme = "bearerAuth";
+
         return new OpenAPI()
                 .info(new Info()
                         .title("OurDressingTable API")
                         .description("화장품 관리 서비스 API 문서")
-                        .version("v1.0"));
+                        .version("v1.0"))
+                .addSecurityItem(new SecurityRequirement().addList(securityScheme))
+                .components(new Components().addSecuritySchemes(securityScheme,
+                        new SecurityScheme()
+                                .name(securityScheme)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/backend/src/main/java/com/ourdressingtable/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ourdressingtable/common/exception/ErrorCode.java
@@ -17,8 +17,10 @@ public enum ErrorCode {
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "M006",
             "비밀번호는 최소 8자 이상, 알파벳 대/소문자, 숫자, 특수문자를 포함해야 합니다."),
     MEMBER_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "M007", "활동 불가 회원입니다."),
+    ALREADY_WITHDRAW_OR_BLOCKED(HttpStatus.BAD_REQUEST, "M008", "이미 탈퇴 또는 차단된 회원입니다."),
 
     // 인증/인가 관련
+
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "로그인이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
 

--- a/backend/src/main/java/com/ourdressingtable/community/post/dto/CreatePostRequest.java
+++ b/backend/src/main/java/com/ourdressingtable/community/post/dto/CreatePostRequest.java
@@ -21,9 +21,11 @@ public class CreatePostRequest {
     @NotBlank(message = "내용을 입력해주세요.")
     private String content;
 
+    @Schema(description = "카테고리", example = "1")
     @NotNull(message = "카테고리를 선택해주세요.")
     private Long communityCategoryId;
 
+    @Schema(description = "이미지", example = "imageUrl")
     private List<String> images;
 
     @Builder

--- a/backend/src/main/java/com/ourdressingtable/community/post/service/PostServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/community/post/service/PostServiceImpl.java
@@ -32,7 +32,7 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public Long createPost(CreatePostRequest request, Long memberId) {
         CommunityCategory communityCategory = communityCategoryService.getCategoryEntityById(request.getCommunityCategoryId());
-        Member member = memberService.getMemberEntityById(memberId);
+        Member member = memberService.getActiveMemberEntityById(memberId);
         Post post = Post.builder()
                 .title(request.getTitle())
                 .content(request.getContent())

--- a/backend/src/main/java/com/ourdressingtable/community/service/CommunityServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/community/service/CommunityServiceImpl.java
@@ -27,7 +27,10 @@ public class CommunityServiceImpl implements CommunityService {
 
     @Override
     public Long createPost(CreatePostRequest createPostRequest, Long memberId) {
-        Member member = memberService.getMemberEntityById(memberId);
+        Member member = memberService.getActiveMemberEntityById(memberId);
+        if(member == null) {
+            throw new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND);
+        }
         return postService.createPost(createPostRequest, memberId);
     }
 

--- a/backend/src/main/java/com/ourdressingtable/community/service/CommunityServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/community/service/CommunityServiceImpl.java
@@ -26,6 +26,7 @@ public class CommunityServiceImpl implements CommunityService {
     private final PostLikeService postLikeService;
 
     @Override
+    @Transactional
     public Long createPost(CreatePostRequest createPostRequest, Long memberId) {
         Member member = memberService.getActiveMemberEntityById(memberId);
         if(member == null) {
@@ -35,12 +36,14 @@ public class CommunityServiceImpl implements CommunityService {
     }
 
     @Override
+    @Transactional
     public void updatePost(Long postId, Long memberId, UpdatePostRequest updatePostRequest) {
         checkPermission(postId, memberId);
         postService.updatePost(postId, updatePostRequest);
     }
 
     @Override
+    @Transactional
     public void deletePost(Long postId, Long memberId) {
         checkPermission(postId, memberId);
         postService.deletePost(postId);
@@ -58,7 +61,7 @@ public class CommunityServiceImpl implements CommunityService {
         Post post = postService.getValidPostEntityById(postId);
         boolean liked = false;
         if(memberId != null){
-            liked = postLikeService.hasLiked(memberId, postId);
+            liked = postLikeService.hasLiked(postId, memberId);
         }
         return PostDetailResponse.from(post, liked);
     }

--- a/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.ourdressingtable.member.controller;
 
+import com.ourdressingtable.common.exception.ErrorCode;
+import com.ourdressingtable.common.exception.OurDressingTableException;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.CreateMemberResponse;
 import com.ourdressingtable.member.dto.MemberResponse;
@@ -8,6 +10,7 @@ import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
 import com.ourdressingtable.member.dto.WithdrawalMemberResponse;
 import com.ourdressingtable.member.service.MemberService;
+import com.ourdressingtable.security.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -15,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.sql.Update;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -55,25 +59,31 @@ public class MemberController {
     }
 
     // 다른 회원 프로필 조회
-    @GetMapping("/{userId}")
+    @GetMapping("/{memberId}")
     @Operation(summary = "다른 회원 조회", description = "다른 회원의 프로필을 조회합니다.")
-    public ResponseEntity<OtherMemberResponse> getMember(@PathVariable("userId") Long userId) {
-        OtherMemberResponse otherMemberResponse = memberService.getMember(userId);
+    public ResponseEntity<OtherMemberResponse> getOtherMember(@PathVariable("memberId") Long memberId) {
+        OtherMemberResponse otherMemberResponse = memberService.getOtherMember(memberId);
         return ResponseEntity.ok(otherMemberResponse);
 
     }
 
-    @PatchMapping("/{userId}")
+    @PatchMapping("/{memberId}")
     @Operation(summary = "회원 수정", description = "회원 정보를 수정합니다.")
-    public ResponseEntity updateMember(@PathVariable("userId") Long userId, @RequestBody @Valid UpdateMemberRequest updateMemberRequest) {
-        memberService.updateMember(userId, updateMemberRequest);
+    public ResponseEntity updateMember(@PathVariable("memberId") Long memberId, @RequestBody @Valid UpdateMemberRequest updateMemberRequest, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        if(!memberId.equals(customUserDetails.getMemberId())) {
+            throw new OurDressingTableException(ErrorCode.FORBIDDEN);
+        }
+        memberService.updateMember(memberId, updateMemberRequest);
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{userId}")
+    @DeleteMapping("/{memberId}")
     @Operation(summary = "회원 삭제", description = "회원을 삭제합니다.")
-    public ResponseEntity deleteMember(@PathVariable("userId") Long userId, @RequestBody @Valid WithdrawalMemberRequest withdrawalMemberRequest) {
-        memberService.deleteMember(userId, withdrawalMemberRequest);
+    public ResponseEntity deleteMember(@PathVariable("memberId") Long memberId, @RequestBody @Valid WithdrawalMemberRequest withdrawalMemberRequest, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        if(!memberId.equals(customUserDetails.getMemberId())) {
+            throw new OurDressingTableException(ErrorCode.FORBIDDEN);
+        }
+        memberService.deleteMember(memberId, withdrawalMemberRequest);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
@@ -2,21 +2,21 @@ package com.ourdressingtable.member.controller;
 
 import com.ourdressingtable.common.exception.ErrorCode;
 import com.ourdressingtable.common.exception.OurDressingTableException;
+import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.CreateMemberResponse;
 import com.ourdressingtable.member.dto.MemberResponse;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
-import com.ourdressingtable.member.dto.WithdrawalMemberResponse;
 import com.ourdressingtable.member.service.MemberService;
 import com.ourdressingtable.security.dto.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.sql.Update;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,7 +35,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
-//    private final PasswordEncoder passwordEncoder;
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입", description = "새로운 회원이 가입합니다.")
@@ -68,7 +67,7 @@ public class MemberController {
     }
 
     @PatchMapping("/{memberId}")
-    @Operation(summary = "회원 수정", description = "회원 정보를 수정합니다.")
+    @Operation(summary = "회원 수정", description = "회원 정보를 수정합니다.", security = @SecurityRequirement(name="bearerAuth"))
     public ResponseEntity updateMember(@PathVariable("memberId") Long memberId, @RequestBody @Valid UpdateMemberRequest updateMemberRequest, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         if(!memberId.equals(customUserDetails.getMemberId())) {
             throw new OurDressingTableException(ErrorCode.FORBIDDEN);
@@ -78,12 +77,30 @@ public class MemberController {
     }
 
     @DeleteMapping("/{memberId}")
-    @Operation(summary = "회원 삭제", description = "회원을 삭제합니다.")
+    @Operation(summary = "회원 삭제", description = "회원을 삭제합니다.", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity deleteMember(@PathVariable("memberId") Long memberId, @RequestBody @Valid WithdrawalMemberRequest withdrawalMemberRequest, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         if(!memberId.equals(customUserDetails.getMemberId())) {
             throw new OurDressingTableException(ErrorCode.FORBIDDEN);
         }
-        memberService.deleteMember(memberId, withdrawalMemberRequest);
+        memberService.withdrawMember(memberId, withdrawalMemberRequest);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/my-information")
+    @Operation(summary = "내 정보 조회", description = "내 정보를 조회합니다.")
+    public ResponseEntity<?> getCurrentMember(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Member member = memberService.getActiveMemberEntityById(userDetails.getMemberId());
+        MemberResponse response = MemberResponse.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .imageUrl(member.getImageUrl())
+                .phoneNumber(member.getPhoneNumber())
+                .skinType(member.getSkinType())
+                .colorType(member.getColorType())
+                .birthDate(member.getBirthDate())
+                .role(member.getRole().getAuth())
+                .build();
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/ourdressingtable/member/domain/Member.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/Member.java
@@ -96,6 +96,18 @@ public class Member extends BaseTimeEntity {
         this.imageUrl = getOrDefault(updateMemberRequest.getImageUrl(),this.imageUrl);
     }
 
+    public void withdraw() {
+        this.status = Status.WITHDRAWAL;
+    }
+
+    public void block() {
+        this.status = Status.BLOCK;
+    }
+
+    public void active() {
+        this.status = Status.ACTIVATE;
+    }
+
     private String getOrDefault(String newValue, String currentValue) {
         return (newValue == null || newValue.isBlank()) ? currentValue : newValue;
     }

--- a/backend/src/main/java/com/ourdressingtable/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/ourdressingtable/member/repository/MemberRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
-
     Optional<Member > findByEmail(String email);
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
@@ -9,10 +9,11 @@ import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
 
 public interface MemberService {
     Long createMember(CreateMemberRequest createMemberRequest);
-    OtherMemberResponse getMember(Long id);
+    OtherMemberResponse getOtherMember(Long id);
     void updateMember(Long id, UpdateMemberRequest updateMemberRequest);
     void deleteMember(Long id, WithdrawalMemberRequest withdrawalMemberRequest );
     Long createWithdrawalMember(WithdrawalMemberRequest withdrawalMemberRequest, Member member);
     Member getMemberEntityById(Long id);
     Member getActiveMemberEntityById(Long id);
+    Member getActiveMemberEntityByEmail(String email);
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/MemberService.java
@@ -2,7 +2,6 @@ package com.ourdressingtable.member.service;
 
 import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
-import com.ourdressingtable.member.dto.MemberResponse;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
@@ -11,8 +10,7 @@ public interface MemberService {
     Long createMember(CreateMemberRequest createMemberRequest);
     OtherMemberResponse getOtherMember(Long id);
     void updateMember(Long id, UpdateMemberRequest updateMemberRequest);
-    void deleteMember(Long id, WithdrawalMemberRequest withdrawalMemberRequest );
-    Long createWithdrawalMember(WithdrawalMemberRequest withdrawalMemberRequest, Member member);
+    void withdrawMember(Long id, WithdrawalMemberRequest withdrawalMemberRequest );
     Member getMemberEntityById(Long id);
     Member getActiveMemberEntityById(Long id);
     Member getActiveMemberEntityByEmail(String email);

--- a/backend/src/main/java/com/ourdressingtable/member/service/WithdrawalMemberService.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/WithdrawalMemberService.java
@@ -1,0 +1,9 @@
+package com.ourdressingtable.member.service;
+
+import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
+
+public interface WithdrawalMemberService {
+
+    void createWithdrawalMember(WithdrawalMemberRequest withdrawalMemberRequest, Member member);
+}

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
@@ -41,7 +41,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public OtherMemberResponse getMember(Long id) {
+    public OtherMemberResponse getOtherMember(Long id) {
         Member member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
         return OtherMemberResponse.fromEntity(member);
     }
@@ -50,6 +50,7 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public void updateMember(Long id, UpdateMemberRequest updateMemberRequest) {
         Member member = memberRepository.findById(id).orElseThrow(()->new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
+
         member.updateMember(updateMemberRequest);
     }
 
@@ -83,9 +84,23 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
 
         if(!member.getStatus().equals(Status.ACTIVATE)) {
-            throw new OurDressingTableException(ErrorCode.MEMBER_NOT_ACTIVE);
+            throw new OurDressingTableException(ErrorCode.FORBIDDEN);
 
         }
         return member;
+    }
+
+    @Override
+    public Member getActiveMemberEntityByEmail(String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
+        if(!member.getStatus().equals(Status.ACTIVATE)) {
+            throw new OurDressingTableException(ErrorCode.FORBIDDEN);
+        }
+        return member;
+
+    }
+
+    private void checkMember(Long memberId) {
+
     }
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/WithdrawalMemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/WithdrawalMemberServiceImpl.java
@@ -1,0 +1,28 @@
+package com.ourdressingtable.member.service.impl;
+
+import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.member.domain.Status;
+import com.ourdressingtable.member.domain.WithdrawalMember;
+import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
+import com.ourdressingtable.member.repository.WithdrawalMemberRepository;
+import com.ourdressingtable.member.service.WithdrawalMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WithdrawalMemberServiceImpl implements WithdrawalMemberService {
+
+    private final WithdrawalMemberRepository withdrawalMemberRepository;
+
+    @Override
+    public void createWithdrawalMember(WithdrawalMemberRequest request, Member member) {
+        boolean isBlocked = member.getStatus() == Status.BLOCK;
+
+        WithdrawalMember withdrawalMember = WithdrawalMember.from(member, request, isBlocked);
+        withdrawalMemberRepository.save(withdrawalMember);
+    }
+
+}

--- a/backend/src/main/java/com/ourdressingtable/security/controller/AuthController.java
+++ b/backend/src/main/java/com/ourdressingtable/security/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.ourdressingtable.security.dto.LoginRequest;
 import com.ourdressingtable.security.dto.LoginResponse;
 import com.ourdressingtable.security.dto.RefreshTokenRequest;
 import com.ourdressingtable.security.dto.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ public class AuthController {
     private final RedisTokenService redisTokenService;
 
     @PostMapping("/login")
+    @Operation(summary = "로그인", description = "로그인을 합니다.")
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request, HttpServletRequest httpServletRequest) {
         authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
@@ -55,6 +57,7 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
+    @Operation(summary = "refresh token 재발급", description = "refresh token 재발급합니다.")
     public ResponseEntity<TokenResponse> refreshToken(@RequestBody RefreshTokenRequest request, HttpServletRequest httpServletRequest) {
         String token = request.getRefreshToken();
 
@@ -77,24 +80,8 @@ public class AuthController {
         return ResponseEntity.ok(TokenResponse.builder().accessToken(newAccessToken).refreshToken(newRefreshToken).build());
     }
 
-    @GetMapping("/me")
-    public ResponseEntity<?> getCurrentMember(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        Member member = memberService.getActiveMemberEntityById(userDetails.getMemberId());
-        MemberResponse response = MemberResponse.builder()
-                .name(member.getName())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .imageUrl(member.getImageUrl())
-                .phoneNumber(member.getPhoneNumber())
-                .skinType(member.getSkinType())
-                .colorType(member.getColorType())
-                .birthDate(member.getBirthDate())
-                .role(member.getRole().getAuth())
-                .build();
-        return ResponseEntity.ok(response);
-    }
-
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃을 합니다.")
     public ResponseEntity logout(HttpServletRequest httpServletRequest) {
         log.info("[logout] 호출");
         String token = jwtTokenProvider.resolveToken(httpServletRequest);

--- a/backend/src/main/java/com/ourdressingtable/security/dto/LoginRequest.java
+++ b/backend/src/main/java/com/ourdressingtable/security/dto/LoginRequest.java
@@ -1,5 +1,8 @@
 package com.ourdressingtable.security.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -12,7 +15,13 @@ import lombok.Setter;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class LoginRequest {
 
+    @Schema(description = "이메일", example = "sample@gmail.com")
+    @NotBlank(message = "이메일을 입려해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
+
+    @Schema(description = "비밀번호", example = "Password123!@@@@@@@?")
+    @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
     @Builder

--- a/backend/src/main/java/com/ourdressingtable/security/dto/LoginResponse.java
+++ b/backend/src/main/java/com/ourdressingtable/security/dto/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.ourdressingtable.security.dto;
 
 import com.ourdressingtable.member.domain.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,14 +9,31 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LoginResponse {
 
+    @Schema(description = "발급된 accessToken", example = "accessToken")
     private String accessToken;
+
+    @Schema(description = "발급된 refreshToken", example = "refreshToken")
     private String refreshToken;
+
+    @Schema(description = "발급된 token type", example = "Bearer")
     private String tokenType = "Bearer";
+
+    @Schema(description = "로그인 된 회원 ID", example = "1")
     private Long memberId;
+
+    @Schema(description = "로그인 된 회원 EMAIL", example = "sample@gmail.com")
     private String email;
+
+    @Schema(description = "로그인 된 회원 이름", example = "김이름")
     private String name;
+
+    @Schema(description = "로그인 된 회원 닉네임", example = "닉네임네임")
     private String nickname;
+
+    @Schema(description = "로그인 된 회원 프로필 이미지", example = "image_url")
     private String imageUrl;
+
+    @Schema(description = "로그인 된 회원 ROLE", example = "ROLE_BASIC")
     private Role role;
 
     @Builder

--- a/backend/src/main/java/com/ourdressingtable/security/dto/RefreshTokenRequest.java
+++ b/backend/src/main/java/com/ourdressingtable/security/dto/RefreshTokenRequest.java
@@ -1,5 +1,7 @@
 package com.ourdressingtable.security.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -12,6 +14,8 @@ import lombok.Setter;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class RefreshTokenRequest {
 
+    @Schema(description = "refresh token", example = "refresh token")
+    @NotBlank
     private String refreshToken;
 
     @Builder

--- a/backend/src/main/java/com/ourdressingtable/security/dto/TokenResponse.java
+++ b/backend/src/main/java/com/ourdressingtable/security/dto/TokenResponse.java
@@ -1,12 +1,16 @@
 package com.ourdressingtable.security.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class TokenResponse {
 
+    @Schema(description = "accesstoken", example = "accesstoken")
     private String accessToken;
+
+    @Schema(description = "refreshtoken", example = "refreshtoken")
     private String refreshToken;
 
     @Builder

--- a/backend/src/test/java/com/ourdressingtable/common/security/TestSecurityConfig.java
+++ b/backend/src/test/java/com/ourdressingtable/common/security/TestSecurityConfig.java
@@ -1,0 +1,19 @@
+package com.ourdressingtable.common.security;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/backend/src/test/java/com/ourdressingtable/common/security/WithCustomUser.java
+++ b/backend/src/test/java/com/ourdressingtable/common/security/WithCustomUser.java
@@ -1,0 +1,22 @@
+package com.ourdressingtable.common.security;
+
+import com.ourdressingtable.member.domain.Role;
+import com.ourdressingtable.member.domain.Status;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomUserSecurityContextFactory.class)
+public @interface WithCustomUser {
+
+    long memberId() default 1L;
+    String email() default "test@example.com";
+    String password() default "password";
+    Role role() default Role.ROLE_BASIC;
+    Status status() default Status.ACTIVATE;
+
+}

--- a/backend/src/test/java/com/ourdressingtable/common/security/WithCustomUserSecurityContextFactory.java
+++ b/backend/src/test/java/com/ourdressingtable/common/security/WithCustomUserSecurityContextFactory.java
@@ -1,0 +1,36 @@
+package com.ourdressingtable.common.security;
+
+import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.security.dto.CustomUserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomUser customUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        Member member = Member.builder()
+                .id(customUser.memberId())
+                .email(customUser.email())
+                .build();
+
+        CustomUserDetails userDetails = CustomUserDetails.builder()
+                .memberId(customUser.memberId())
+                .email(customUser.email())
+                .password(customUser.password())
+                .role(customUser.role())
+                .status(customUser.status())
+                .build();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+
+        context.setAuthentication(authentication);
+        return context;
+    }
+
+}

--- a/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
+++ b/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
@@ -1,0 +1,81 @@
+package com.ourdressingtable.common.util;
+
+import com.ourdressingtable.community.post.domain.Post;
+import com.ourdressingtable.community.post.dto.CreatePostRequest;
+import com.ourdressingtable.community.post.dto.UpdatePostRequest;
+import com.ourdressingtable.communityCategory.domain.CommunityCategory;
+import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.member.domain.Role;
+import com.ourdressingtable.member.domain.SkinType;
+import com.ourdressingtable.member.domain.Status;
+import com.ourdressingtable.member.dto.CreateMemberRequest;
+import com.ourdressingtable.member.dto.OtherMemberResponse;
+import com.ourdressingtable.member.dto.UpdateMemberRequest;
+import com.ourdressingtable.security.dto.CustomUserDetails;
+
+public class TestDataFactory {
+
+    public static Member testMember(Long id) {
+        return Member.builder()
+                .id(id)
+                .email("test@example.com")
+                .build();
+    }
+
+    public static CreateMemberRequest testCreateMemberRequest() {
+        return CreateMemberRequest.builder()
+                .email("member1@gmail.com")
+                .password("Password123!")
+                .name("member1")
+                .nickname("me")
+                .phoneNumber("010-1234-5678")
+                .build();
+    }
+
+    public static UpdateMemberRequest testUpdateMemberRequest() {
+        return UpdateMemberRequest.builder().nickname("new me").build();
+    }
+
+    public static OtherMemberResponse testOtherMemberResponse() {
+        return OtherMemberResponse.builder()
+                .nickname("me")
+                .skinType(SkinType.OILY_SKIN)
+                .build();
+    }
+
+    public static CreatePostRequest testCreatePostRequest() {
+        return CreatePostRequest.builder()
+                .title("Test 제목")
+                .content("Test 내용")
+                .communityCategoryId(1L)
+                .build();
+    }
+
+    public static UpdatePostRequest testUpdatePostRequest() {
+        return UpdatePostRequest.builder()
+                .title("수정 제목")
+                .content("수정 내용")
+                .communityCategoryId(2L)
+                .build();
+    }
+
+    public static CustomUserDetails testUserDetails(Long memberId) {
+        return CustomUserDetails.builder()
+                .memberId(memberId)
+                .email("user" + memberId + "@example.com")
+                .password("password")
+                .role(Role.ROLE_BASIC)
+                .status(Status.ACTIVATE)
+                .build();
+    }
+    public static Post testPost(Long id, Member member) {
+        return Post.builder()
+                .id(id)
+                .title("제목")
+                .content("내용")
+                .member(member)
+                .communityCategory(CommunityCategory.builder().id(1L).build())
+                .build();
+    }
+
+}

--- a/backend/src/test/java/com/ourdressingtable/community/domain/post/controller/PostLikeControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/community/domain/post/controller/PostLikeControllerTest.java
@@ -3,6 +3,8 @@ package com.ourdressingtable.community.domain.post.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ourdressingtable.common.exception.ErrorCode;
 import com.ourdressingtable.common.exception.OurDressingTableException;
+import com.ourdressingtable.common.security.WithCustomUser;
+import com.ourdressingtable.common.util.TestDataFactory;
 import com.ourdressingtable.community.post.controller.PostLikeController;
 import com.ourdressingtable.community.post.domain.Post;
 import com.ourdressingtable.community.post.service.PostLikeService;
@@ -20,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -42,22 +45,25 @@ public class PostLikeControllerTest {
     @DisplayName("게시글 좋아요 등록 테스트")
     class PostLikeTest{
         @DisplayName("게시글 좋아요 등록 테스트 성공")
+        @WithCustomUser
         @Test
         public void createPostLike_ReturnSuccess() throws Exception {
             // given
-            Post post = Post.builder().id(1L).build();
-            Member member = Member.builder().id(1L).build();
+            Member member = TestDataFactory.testMember(1L);
+            Post post = TestDataFactory.testPost(1L, member);
             given(postLikeService.toggleLike(post.getId(), member.getId())).willReturn(true);
 
             // when & then
             mockMvc.perform(post("/api/posts/{postId}/like", post.getId())
-                            .param("memberId", member.getId().toString())
-            .contentType(MediaType.APPLICATION_JSON))
+                    .param("memberId", member.getId().toString())
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.liked").value(true));
         }
 
         @DisplayName("게시글 좋아요 등록 테스트 실패")
+        @WithCustomUser
         @Test
         public void createPostLike_ReturnFailure() throws Exception {
             doThrow(new OurDressingTableException(ErrorCode.MEMBER_NOT_ACTIVE))
@@ -66,6 +72,7 @@ public class PostLikeControllerTest {
             Long memberId = 1L;
             mockMvc.perform(post("/api/posts/{postId}/like", postId)
                     .param("memberId", memberId.toString())
+                    .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest());
         }

--- a/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
@@ -1,8 +1,10 @@
 package com.ourdressingtable.member.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -13,24 +15,33 @@ import static org.mockito.BDDMockito.willThrow;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ourdressingtable.common.exception.ErrorCode;
 import com.ourdressingtable.common.exception.OurDressingTableException;
+import com.ourdressingtable.common.security.TestSecurityConfig;
+import com.ourdressingtable.common.security.WithCustomUser;
+import com.ourdressingtable.common.util.TestDataFactory;
+import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.domain.Role;
 import com.ourdressingtable.member.domain.SkinType;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.member.service.MemberService;
+import com.ourdressingtable.security.auth.JwtAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @ActiveProfiles("test")
 @WebMvcTest(controllers = MemberController.class)
+@Import(TestSecurityConfig.class)
 @DisplayName("회원 기능 테스트")
 public class MemberControllerTest {
 
@@ -43,98 +54,129 @@ public class MemberControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @DisplayName("회원 가입 - 성공")
-    @Test
-    public void signupMember_withValidInput_shouldReturnSuccess() throws Exception {
-        // given
-        CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
-                .email("member1@gmail.com")
-                .password("Password1234!!")
-                .name("member1")
-                .nickname("me")
-                .phoneNumber("010-1234-5678")
-                .build();
+    @Nested
+    @DisplayName("회원 가입 테스트")
+    class createMemberTest{
+        @DisplayName("회원 가입 - 성공")
+        @Test
+        @WithAnonymousUser
+        public void signupMember_withValidInput_shouldReturnSuccess() throws Exception {
+            // given
+            CreateMemberRequest createMemberRequest = TestDataFactory.testCreateMemberRequest();
+            Member member = TestDataFactory.testMember(1L);
+            given(memberService.createMember(any(CreateMemberRequest.class))).willReturn(member.getId());
 
-        Long memberId = 1L;
-        when(memberService.createMember(any(CreateMemberRequest.class))).thenReturn(memberId);
+            // when & then
+            mockMvc.perform(post("/api/members/signup")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(createMemberRequest)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string("Location","/api/members/1"))
+                    .andExpect(jsonPath("$.id").value(member.getId()));
 
-        // when & then
-        mockMvc.perform(post("/api/members/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(createMemberRequest)))
-                .andDo(print())
-                .andExpect(status().isCreated())
-                .andExpect(header().string("Location","/api/members/1"))
-                .andExpect(jsonPath("$.id").value(memberId));
+        }
+
+        @DisplayName("회원 가입 - 실패")
+        @Test
+        @WithAnonymousUser
+        public void signupMember_withInvalidInput_shouldReturnError() throws Exception {
+            // given
+            CreateMemberRequest createMemberRequest = TestDataFactory.testCreateMemberRequest();
+
+            Member member = TestDataFactory.testMember(1L);
+            when(memberService.createMember(any(CreateMemberRequest.class))).thenThrow(new OurDressingTableException(ErrorCode.EMAIL_ALREADY_EXISTS));
+
+            // when & then
+            mockMvc.perform(post("/api/members/signup")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(createMemberRequest)))
+                    .andDo(print())
+                    .andExpect(status().isConflict());
+
+        }
+    }
+
+    @Nested
+    @DisplayName("다른 회원 정보 조회 테스트")
+    @WithCustomUser
+    class getMemberTest {
+        @DisplayName("다른 회원 정보 조회 - 성공")
+        @Test
+        public void getOtherMember_shouldReturnSuccess() throws Exception {
+            //given
+            OtherMemberResponse otherMemberResponse = TestDataFactory.testOtherMemberResponse();
+            //when
+            when(memberService.getOtherMember(1L)).thenReturn(otherMemberResponse);
+            //then
+            mockMvc.perform(MockMvcRequestBuilders.get("/api/members/1")
+                    .with(csrf())).andExpect(status().isOk()).andDo(print());
+
+        }
+
+        @DisplayName("다른 회원 정보 조회 - 실패")
+        @Test
+        public void getOtherMember_shouldReturnError() throws Exception {
+            // given
+            Long memberId = 99L;
+            when(memberService.getOtherMember(memberId)).thenThrow(new OurDressingTableException(
+                    ErrorCode.MEMBER_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.get("/api/members/{id}", memberId).contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound()).andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 정보 수정 테스트")
+    class updateMember {
+        @DisplayName("회원 정보 수정 - 성공")
+        @WithCustomUser
+        @Test
+        public void updateMember_shouldReturnSuccess() throws Exception {
+            // given
+            Long memberId = 1L;
+            UpdateMemberRequest updateMemberRequest = TestDataFactory.testUpdateMemberRequest();
+
+            // when
+            doNothing().when(memberService).updateMember(memberId,updateMemberRequest);
+
+            // then
+            mockMvc.perform(MockMvcRequestBuilders.patch("/api/members/{id}", memberId)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateMemberRequest)))
+                    .andExpect(status().isNoContent()).andDo(print());
+        };
+
+        @DisplayName("회원 정보 수정 - 사용자 불일치")
+        @WithCustomUser
+        @Test
+        public void updateMember_shouldReturnError () throws Exception{
+            //given
+            Long memberId = 2L;
+            UpdateMemberRequest updateMemberRequest = TestDataFactory.testUpdateMemberRequest();
+
+            //when
+            willThrow(new OurDressingTableException(ErrorCode.FORBIDDEN))
+                    .given(memberService).updateMember(memberId,updateMemberRequest);
+
+            //then
+            mockMvc.perform(MockMvcRequestBuilders.patch("/api/members/{id}", memberId)
+            .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateMemberRequest)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN.getMessage()))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.FORBIDDEN.getCode()))
+                    .andDo(print());
+        }
 
     }
 
-    @DisplayName("회원 가입 - 실패")
-    @Test
-    public void signupMember_withInvalidInput_shouldReturnError() throws Exception {
-        // given
-        CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
-                .email("member1@gmail.com")
-                .password("password")
-                .build();
 
-        Long memberId = 1L;
-        when(memberService.createMember(any(CreateMemberRequest.class))).thenReturn(memberId);
 
-        // when & then
-        mockMvc.perform(post("/api/members/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(createMemberRequest)))
-                .andDo(print())
-                .andExpect(status().isBadRequest());
-
-    }
-
-    @DisplayName("다른 회원 정보 조회 - 성공")
-    @Test
-    public void getOtherMember_shouldReturnSuccess() throws Exception {
-        //given
-        OtherMemberResponse otherMemberResponse = OtherMemberResponse.builder()
-                .nickname("me")
-                .skinType(SkinType.OILY_SKIN)
-                .build();
-        //when
-        when(memberService.getMember(1L)).thenReturn(otherMemberResponse);
-        //then
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/members/1")).andExpect(status().isOk()).andDo(print());
-
-    }
-
-    @DisplayName("다른 회원 정보 조회 - 실패")
-    @Test
-    public void getOtherMember_shouldReturnError() throws Exception {
-        // given
-        Long memberId = 99L;
-        when(memberService.getMember(memberId)).thenThrow(new OurDressingTableException(
-                ErrorCode.MEMBER_NOT_FOUND));
-
-        // when & then
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/members/{id}", memberId).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound()).andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
-    }
-
-    @DisplayName("회원 정보 수정 - 성공")
-    @Test
-    public void updateMember_shouldReturnSuccess() throws Exception {
-        // given
-        Long memberId = 1L;
-        UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
-                .nickname("new me")
-                .phoneNumber("010-1234-5678")
-                .build();
-
-        // when
-        doNothing().when(memberService).updateMember(memberId,updateMemberRequest);
-
-        // then
-        mockMvc.perform(MockMvcRequestBuilders.patch("/api/members/{id}", memberId)
-                .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateMemberRequest)))
-                .andExpect(status().isNoContent()).andDo(print());
-    };
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈: 기능명
#8 : 탈퇴 회원
#27 : swagger에 security 적용

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 탈퇴 회원 service 분리
- swagger에 security 적용

### 🧪테스트 여부
- [ ]  테스트 코드
- [x]  API 테스트