### PR TITLE
Community

### DIFF
--- a/backend/src/main/java/com/ourdressingtable/common/util/HashUtil.java
+++ b/backend/src/main/java/com/ourdressingtable/common/util/HashUtil.java
@@ -1,4 +1,6 @@
-package com.ourdressingtable.util;
+package com.ourdressingtable.common.util;
+
+import org.apache.commons.lang3.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -7,6 +9,10 @@ import java.security.NoSuchAlgorithmException;
 public class HashUtil {
 
     public static String hash(String input) {
+        if(StringUtils.isBlank(input)) {
+            throw new IllegalArgumentException("Input cannot be blank or null");
+        }
+
         try{
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));

--- a/backend/src/main/java/com/ourdressingtable/common/util/MaskingUtil.java
+++ b/backend/src/main/java/com/ourdressingtable/common/util/MaskingUtil.java
@@ -1,15 +1,29 @@
-package com.ourdressingtable.util;
+package com.ourdressingtable.common.util;
+
+import com.ourdressingtable.common.exception.OurDressingTableException;
+import org.apache.commons.lang3.StringUtils;
 
 public class MaskingUtil {
 
     public static String maskedEmail(String email) {
+        if(StringUtils.isBlank(email))
+            throw new IllegalArgumentException("Email cannot be null or empty");
+
         String[] parts = email.split("@");
+
+        if(parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty())
+            throw new IllegalArgumentException("Invalid email format");
+
         String namePart = parts[0];
         String domainPart = parts[1];
 
         String maskedName = namePart.charAt(0) + "." + namePart.charAt(0) + "***";
 
         String[] domainParts = domainPart.split("\\.");
+
+        if(domainParts.length != 2 || domainParts[0].isEmpty() || domainParts[1].isEmpty())
+            throw new IllegalArgumentException("Invalid domain format");
+
         String maskedDomain = domainParts[0].charAt(0)+"*****";
 
         return maskedName + "@" + maskedDomain + "." + domainParts[1];
@@ -17,6 +31,12 @@ public class MaskingUtil {
     }
 
     public static String maskedPhone(String phone) {
+        if(StringUtils.isBlank(phone))
+            throw new IllegalArgumentException("Phone cannot be null or empty");
+
+        if(!phone.matches("\\d{3}-\\d{4}-\\d{4}"))
+            throw new IllegalArgumentException("Phone number format must be xxx-xxxx-xxxx");
+
         return phone.replaceAll("(\\d{3})-\\d{4}-(\\d{4})", "$1****$2");
     }
 

--- a/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
@@ -2,15 +2,10 @@ package com.ourdressingtable.member.domain;
 
 import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
 import com.ourdressingtable.util.BaseTimeEntity;
-import com.ourdressingtable.util.HashUtil;
-import com.ourdressingtable.util.MaskingUtil;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.Table;
+import com.ourdressingtable.common.util.HashUtil;
+import com.ourdressingtable.common.util.MaskingUtil;
+import jakarta.persistence.*;
+
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -42,14 +37,20 @@ public class WithdrawalMember {
     @Column(name = "withdrew_at")
     private Timestamp withdrewAt;
 
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
     @Builder
-    public WithdrawalMember(String hashedEmail, String maskedEmail, String hashedPhone, String maskedPhone, String reason, boolean isBlock) {
+    public WithdrawalMember(Long id, String hashedEmail, String maskedEmail, String hashedPhone, String maskedPhone, String reason, boolean isBlock, Member member) {
+        this.id = id;
         this.hashedEmail = hashedEmail;
         this.maskedEmail = maskedEmail;
         this.hashedPhone = hashedPhone;
         this.maskedPhone = maskedPhone;
         this.reason = reason;
         this.isBlock = isBlock;
+        this.member = member;
     }
 
     public static WithdrawalMember from(Member member, WithdrawalMemberRequest withdrawalMemberRequest, boolean isBlock) {
@@ -60,6 +61,7 @@ public class WithdrawalMember {
                 .maskedPhone(MaskingUtil.maskedPhone(member.getPhoneNumber()))
                 .reason(withdrawalMemberRequest.getReason())
                 .isBlock(isBlock)
+                .member(member)
                 .build();
     }
 
@@ -67,6 +69,5 @@ public class WithdrawalMember {
     public void prePersist() {
         this.withdrewAt = Timestamp.valueOf(LocalDateTime.now());
     }
-
 
 }

--- a/backend/src/main/java/com/ourdressingtable/member/dto/WithdrawalMemberResponse.java
+++ b/backend/src/main/java/com/ourdressingtable/member/dto/WithdrawalMemberResponse.java
@@ -12,10 +12,51 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WithdrawalMemberResponse {
 
-    @Schema(description = "생성된 탈퇴 회원 ID", example = "1")
+    @Schema(description = "탈퇴 회원 ID", example = "1")
     private Long id;
+
+    @Schema(description = "탈퇴 회원 암호화 이메일", example = "dfaEDFE2")
+    private String hashedEmail;
+
+    @Schema(description = "탈퇴 회원 마스킹 이메일", example = "d***@sample.com")
+    private String maskedEmail;
+
+    @Schema(description = "탈퇴 회원 암호화 전화번호", example = "dfaEDFE2")
+    private String hashedPhone;
+
+    @Schema(description = "탈퇴 회원 마스킹 전화번호", example = "010-1234-****")
+    private String maskedPhone;
+
+    @Schema(description = "탈퇴 이유", example = "재가입 예정")
+    private String reason;
+
+    @Schema(description = "차단 여부", example = "false")
+    private boolean isBlock;
+
+    @Builder
+    public WithdrawalMemberResponse(Long id, String hashedEmail, String maskedEmail, String hashedPhone, String maskedPhone, String reason, boolean isBlock) {
+        this.id = id;
+        this.hashedEmail = hashedEmail;
+        this.maskedEmail = maskedEmail;
+        this.hashedPhone = hashedPhone;
+        this.maskedPhone = maskedPhone;
+        this.reason = reason;
+        this.isBlock = isBlock;
+    }
+
+    public static WithdrawalMemberResponse from(WithdrawalMember member) {
+        return WithdrawalMemberResponse.builder()
+                .id(member.getId())
+                .hashedEmail(member.getHashedEmail())
+                .maskedEmail(member.getMaskedEmail())
+                .hashedPhone(member.getHashedPhone())
+                .maskedPhone(member.getMaskedPhone())
+                .reason(member.getReason())
+                .isBlock(member.isBlock())
+                .build();
+    }
+
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
@@ -59,7 +59,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public void withdrawMember(Long id, WithdrawalMemberRequest withdrawalMemberRequest) {
-        Memberrrr member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
 
         if(member.getStatus() == Status.BLOCK || member.getStatus() == Status.WITHDRAWAL) {
             throw new OurDressingTableException(ErrorCode.ALREADY_WITHDRAW_OR_BLOCKED);

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
@@ -59,7 +59,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public void withdrawMember(Long id, WithdrawalMemberRequest withdrawalMemberRequest) {
-        Member member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
+        Memberrrr member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
 
         if(member.getStatus() == Status.BLOCK || member.getStatus() == Status.WITHDRAWAL) {
             throw new OurDressingTableException(ErrorCode.ALREADY_WITHDRAW_OR_BLOCKED);
@@ -82,7 +82,7 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(id).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
 
         if(!member.getStatus().equals(Status.ACTIVATE)) {
-            throw new OurDressingTableException(ErrorCode.FORBIDDEN);
+            throw new OurDressingTableException(ErrorCode.MEMBER_NOT_ACTIVE);
 
         }
         return member;
@@ -92,7 +92,7 @@ public class MemberServiceImpl implements MemberService {
     public Member getActiveMemberEntityByEmail(String email) {
         Member member = memberRepository.findByEmail(email).orElseThrow(() -> new OurDressingTableException(ErrorCode.MEMBER_NOT_FOUND));
         if(!member.getStatus().equals(Status.ACTIVATE)) {
-            throw new OurDressingTableException(ErrorCode.FORBIDDEN);
+            throw new OurDressingTableException(ErrorCode.MEMBER_NOT_ACTIVE);
         }
         return member;
 

--- a/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
+++ b/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
@@ -2,6 +2,7 @@ package com.ourdressingtable.common.util;
 
 import com.ourdressingtable.community.post.domain.Post;
 import com.ourdressingtable.community.post.dto.CreatePostRequest;
+import com.ourdressingtable.community.post.dto.PostDetailResponse;
 import com.ourdressingtable.community.post.dto.UpdatePostRequest;
 import com.ourdressingtable.communityCategory.domain.CommunityCategory;
 import com.ourdressingtable.member.domain.Member;
@@ -12,6 +13,8 @@ import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
 import com.ourdressingtable.security.dto.CustomUserDetails;
+
+import java.sql.Timestamp;
 
 public class TestDataFactory {
 
@@ -56,6 +59,20 @@ public class TestDataFactory {
                 .title("수정 제목")
                 .content("수정 내용")
                 .communityCategoryId(2L)
+                .build();
+    }
+
+    public static PostDetailResponse testPostDetailResponse() {
+        return PostDetailResponse.builder()
+                .id(1L)
+                .title("제목")
+                .content("내용")
+                .categoryName("후기")
+                .viewCount(10)
+                .postLikes(5)
+                .likedByCurrentMember(true)
+                .memberName("사용자1")
+                .createdAt(new Timestamp(System.currentTimeMillis()))
                 .build();
     }
 

--- a/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
+++ b/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
@@ -5,13 +5,11 @@ import com.ourdressingtable.community.post.dto.CreatePostRequest;
 import com.ourdressingtable.community.post.dto.PostDetailResponse;
 import com.ourdressingtable.community.post.dto.UpdatePostRequest;
 import com.ourdressingtable.communityCategory.domain.CommunityCategory;
-import com.ourdressingtable.member.domain.Member;
-import com.ourdressingtable.member.domain.Role;
-import com.ourdressingtable.member.domain.SkinType;
-import com.ourdressingtable.member.domain.Status;
+import com.ourdressingtable.member.domain.*;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
+import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
 import com.ourdressingtable.security.dto.CustomUserDetails;
 
 import java.sql.Timestamp;
@@ -22,9 +20,17 @@ public class TestDataFactory {
         return Member.builder()
                 .id(id)
                 .email("test@example.com")
+                .phoneNumber("010-1234-5678")
                 .build();
     }
 
+    public static Member testMemberWithEmailNull(Long id) {
+        return Member.builder()
+                .id(id)
+                .email(null)
+                .phoneNumber("010-1234-5678")
+                .build();
+    }
     public static CreateMemberRequest testCreateMemberRequest() {
         return CreateMemberRequest.builder()
                 .email("member1@gmail.com")
@@ -43,6 +49,13 @@ public class TestDataFactory {
         return OtherMemberResponse.builder()
                 .nickname("me")
                 .skinType(SkinType.OILY_SKIN)
+                .build();
+    }
+
+    public static WithdrawalMemberRequest testWithdrawalMemberRequest() {
+        return WithdrawalMemberRequest.builder()
+                .reason("재가입 예정")
+                .isBlock(false)
                 .build();
     }
 

--- a/backend/src/test/java/com/ourdressingtable/community/domain/post/service/PostServiceImplTest.java
+++ b/backend/src/test/java/com/ourdressingtable/community/domain/post/service/PostServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.ourdressingtable.community.domain.post.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -166,6 +167,36 @@ public class PostServiceImplTest {
 
             assertThrows(OurDressingTableException.class, () -> postService.deletePost(1L));
 
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 ENTITY 조회 테스트")
+    class getPost {
+        @DisplayName("게시글 ENTITY 조회 - 성공")
+        @Test
+        public void getPost_shouldReturnSuccess() {
+            Member member = TestDataFactory.testMember(1L);
+            Post post = TestDataFactory.testPost(1L,member);
+
+            given(memberService.getMemberEntityById(member.getId())).willReturn(member);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+            Post result = postService.getValidPostEntityById(1L);
+
+            assertEquals(post, result);
+
+        }
+        @DisplayName("게시글 ENTITY 조회 실패 - 삭제된 게시글")
+        @Test
+        public void getPost_shouldReturnPostNotFoundError() {
+             Post post = TestDataFactory.testPost(1L,TestDataFactory.testMember(1L));
+             post.markAsDeleted();
+
+             given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+             assertThatThrownBy(() ->postService.getValidPostEntityById(1L)).isInstanceOf(OurDressingTableException.class)
+                     .hasMessageContaining(ErrorCode.POST_NOT_FOUND.getMessage());
         }
     }
 

--- a/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
@@ -112,7 +112,7 @@ public class MemberControllerTest {
             when(memberService.getOtherMember(1L)).thenReturn(otherMemberResponse);
             //then
             mockMvc.perform(MockMvcRequestBuilders.get("/api/members/1")
-                    .with(csrf())).andExpect(status().isOk()).andDo(print());
+                    .with(csrf())).andExpect(status().isOk()).andDo(print()).andExpect(jsonPath("$.nickname").value("me"));
 
         }
 

--- a/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/controller/MemberControllerTest.java
@@ -2,10 +2,9 @@ package com.ourdressingtable.member.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -24,6 +23,7 @@ import com.ourdressingtable.member.domain.SkinType;
 import com.ourdressingtable.member.dto.CreateMemberRequest;
 import com.ourdressingtable.member.dto.OtherMemberResponse;
 import com.ourdressingtable.member.dto.UpdateMemberRequest;
+import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
 import com.ourdressingtable.member.service.MemberService;
 import com.ourdressingtable.security.auth.JwtAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
@@ -111,7 +111,7 @@ public class MemberControllerTest {
             //when
             when(memberService.getOtherMember(1L)).thenReturn(otherMemberResponse);
             //then
-            mockMvc.perform(MockMvcRequestBuilders.get("/api/members/1")
+            mockMvc.perform(get("/api/members/1")
                     .with(csrf())).andExpect(status().isOk()).andDo(print()).andExpect(jsonPath("$.nickname").value("me"));
 
         }
@@ -125,7 +125,7 @@ public class MemberControllerTest {
                     ErrorCode.MEMBER_NOT_FOUND));
 
             // when & then
-            mockMvc.perform(MockMvcRequestBuilders.get("/api/members/{id}", memberId).contentType(MediaType.APPLICATION_JSON))
+            mockMvc.perform(get("/api/members/{id}", memberId).contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isNotFound()).andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
         }
     }
@@ -145,7 +145,7 @@ public class MemberControllerTest {
             doNothing().when(memberService).updateMember(memberId,updateMemberRequest);
 
             // then
-            mockMvc.perform(MockMvcRequestBuilders.patch("/api/members/{id}", memberId)
+            mockMvc.perform(patch("/api/members/{id}", memberId)
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateMemberRequest)))
                     .andExpect(status().isNoContent()).andDo(print());
@@ -164,7 +164,7 @@ public class MemberControllerTest {
                     .given(memberService).updateMember(memberId,updateMemberRequest);
 
             //then
-            mockMvc.perform(MockMvcRequestBuilders.patch("/api/members/{id}", memberId)
+            mockMvc.perform(patch("/api/members/{id}", memberId)
             .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(updateMemberRequest)))
@@ -176,6 +176,44 @@ public class MemberControllerTest {
 
     }
 
+    @Nested
+    @DisplayName("회원 삭제 테스트")
+    class deleteMember {
+        @DisplayName("회원 삭제 - 성공")
+        @WithCustomUser
+        @Test
+        public void deleteMember_shouldReturnSuccess() throws Exception {
+            // given
+            Long memberId = 1L;
+            WithdrawalMemberRequest withdrawalMemberRequest = TestDataFactory.testWithdrawalMemberRequest();
+
+            mockMvc.perform(delete("/api/members/{id}", memberId)
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(withdrawalMemberRequest)))
+                    .andExpect(status().isNoContent()).andDo(print());
+
+            verify(memberService).withdrawMember(eq(memberId),any(WithdrawalMemberRequest.class));
+
+        };
+
+        @DisplayName("회원 삭제 실패 - 사용자 불일치")
+        @WithCustomUser
+        @Test
+        public void deleteMember_shouldReturnError () throws Exception{
+            Long targetMemberId = 2L;
+            WithdrawalMemberRequest withdrawalMemberRequest = TestDataFactory.testWithdrawalMemberRequest();
+
+            mockMvc.perform(delete("/api/members/{id}", targetMemberId)
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(withdrawalMemberRequest)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN.getMessage()))
+                    .andDo(print());
+        }
+
+    }
 
 
 

--- a/backend/src/test/java/com/ourdressingtable/member/service/WithdrawalMemberServiceImplTest.java
+++ b/backend/src/test/java/com/ourdressingtable/member/service/WithdrawalMemberServiceImplTest.java
@@ -1,0 +1,74 @@
+package com.ourdressingtable.member.service;
+
+import com.ourdressingtable.common.util.TestDataFactory;
+import com.ourdressingtable.member.domain.Member;
+import com.ourdressingtable.member.domain.WithdrawalMember;
+import com.ourdressingtable.member.dto.UpdateMemberRequest;
+import com.ourdressingtable.member.dto.WithdrawalMemberRequest;
+import com.ourdressingtable.member.repository.WithdrawalMemberRepository;
+import com.ourdressingtable.member.service.impl.WithdrawalMemberServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("WithdrawalMemberService 테스트")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class WithdrawalMemberServiceImplTest {
+
+    @InjectMocks
+    private WithdrawalMemberServiceImpl withdrawalMemberService;
+
+    @Mock
+    private WithdrawalMemberRepository withdrawalMemberRepository;
+
+    @Nested
+    @DisplayName("탈퇴 회원 테스트")
+    class createWithdrawalMemberTest {
+
+        @DisplayName("탈퇴 회원 저장 성공")
+        @Test
+        public void createWithdrawalMember_shouldReturnSuccess() {
+            // given
+            Member member = TestDataFactory.testMember(1L);
+            WithdrawalMemberRequest request = TestDataFactory.testWithdrawalMemberRequest();
+
+            // when
+            withdrawalMemberService.createWithdrawalMember(request, member);
+            ArgumentCaptor<WithdrawalMember> captor = ArgumentCaptor.forClass(WithdrawalMember.class);
+            verify(withdrawalMemberRepository).save(captor.capture());
+
+            WithdrawalMember withdrawalMember = captor.getValue();
+            assertEquals(member.getId(), withdrawalMember.getMember().getId());
+            assertEquals(request.getReason(), withdrawalMember.getReason());
+        }
+
+        @DisplayName("탈퇴 회원 저장 실패 - 이메일 null")
+        @Test
+        void createWithdrawalMember_shouldFail_whenEmailIsNull() {
+            // given
+            Member member = TestDataFactory.testMemberWithEmailNull(1L);
+            WithdrawalMemberRequest request = TestDataFactory.testWithdrawalMemberRequest();
+
+            // when & then
+            assertThrows(IllegalArgumentException.class, () -> {
+                withdrawalMemberService.createWithdrawalMember(request, member);
+            });
+
+            verify(withdrawalMemberRepository, never()).save(any());
+
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈: 기능명
#8 : 탈퇴 회원 테스트 추가
#18 : 게시글 단건 조회 테스트 추가

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 탈퇴 회원 controller, service 테스트 
- 게시글 단건 조회 controller, service 테스트 
- hash, masking util에 input null 체크

### 🧪테스트 여부
- [x]  테스트 코드
- [x]  API 테스트
