### PR TITLE
탈퇴 회원 재가입 확

### DIFF
--- a/backend/src/main/java/com/ourdressingtable/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ourdressingtable/common/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     MEMBER_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "M007", "활동 불가 회원입니다."),
     ALREADY_WITHDRAW_OR_BLOCKED(HttpStatus.BAD_REQUEST, "M008", "이미 탈퇴 또는 차단된 회원입니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "M009", "이미 사용중인 닉네임입니다."),
-    
+    WITHDRAWN_MEMBER_RESTRICTED(HttpStatus.FORBIDDEN, "M010", "탈퇴한 회원은 일정 기간 내 재가입할 수 없습니다."),
+    WITHDRAWN_BLOCK_MEMBER_RESTRICTED(HttpStatus.FORBIDDEN, "M11", "차단 당한 회원은 재가입 할 수 없습니다."),
 
     // 인증/인가 관련
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "로그인이 필요합니다."),

--- a/backend/src/main/java/com/ourdressingtable/common/exception/OurDressingTableException.java
+++ b/backend/src/main/java/com/ourdressingtable/common/exception/OurDressingTableException.java
@@ -22,4 +22,10 @@ public class OurDressingTableException extends RuntimeException {
         this.httpStatus = errorCode.getHttpStatus();
         this.code = errorCode.getCode();
     }
+
+    public OurDressingTableException(ErrorCode errorCode, String msg) {
+        super(msg);
+        this.httpStatus = errorCode.getHttpStatus();
+        this.code = errorCode.getCode();
+    }
 }

--- a/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
+++ b/backend/src/main/java/com/ourdressingtable/member/domain/WithdrawalMember.java
@@ -41,7 +41,7 @@ public class WithdrawalMember {
     private Member member;
 
     @Builder
-    public WithdrawalMember(Long id, String hashedEmail, String maskedEmail, String hashedPhone, String maskedPhone, String reason, boolean isBlock, Member member) {
+    public WithdrawalMember(Long id, String hashedEmail, String maskedEmail, String hashedPhone, String maskedPhone, String reason, boolean isBlock, Member member, Timestamp withdrewAt) {
         this.id = id;
         this.hashedEmail = hashedEmail;
         this.maskedEmail = maskedEmail;
@@ -50,6 +50,7 @@ public class WithdrawalMember {
         this.reason = reason;
         this.isBlock = isBlock;
         this.member = member;
+        this.withdrewAt = withdrewAt;
     }
 
     public static WithdrawalMember from(Member member, WithdrawalMemberRequest withdrawalMemberRequest, boolean isBlock) {

--- a/backend/src/main/java/com/ourdressingtable/member/repository/WithdrawalMemberRepository.java
+++ b/backend/src/main/java/com/ourdressingtable/member/repository/WithdrawalMemberRepository.java
@@ -1,8 +1,10 @@
 package com.ourdressingtable.member.repository;
 
 import com.ourdressingtable.member.domain.WithdrawalMember;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WithdrawalMemberRepository extends JpaRepository<WithdrawalMember, Long> {
 
+    Optional<WithdrawalMember> findByHashedEmail(String hashedEmail);
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/WithdrawalMemberService.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/WithdrawalMemberService.java
@@ -6,4 +6,5 @@ import com.ourdressingtable.member.dto.request.WithdrawalMemberRequest;
 public interface WithdrawalMemberService {
 
     void createWithdrawalMember(WithdrawalMemberRequest withdrawalMemberRequest, Member member);
+    void validateWithdrawalMember(String email);
 }

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/MemberServiceImpl.java
@@ -32,6 +32,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public Long createMember(CreateMemberRequest createMemberRequest) {
+
         if (!emailVerificationRepository.isVerified(createMemberRequest.getEmail())) {
             throw new OurDressingTableException(ErrorCode.EMAIL_NOT_VERIFIED);
         }
@@ -42,6 +43,9 @@ public class MemberServiceImpl implements MemberService {
         if (memberRepository.existsByNickname(createMemberRequest.getNickname())) {
             throw new OurDressingTableException(ErrorCode.NICKNAME_ALREADY_EXISTS);
         }
+
+        withdrawalMemberService.validateWithdrawalMember(createMemberRequest.getEmail());
+
         String encodedPassword = passwordEncoder.encode(createMemberRequest.getPassword());
         Member member = createMemberRequest.toEntity(encodedPassword);
         member.active();

--- a/backend/src/main/java/com/ourdressingtable/member/service/impl/WithdrawalMemberServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/member/service/impl/WithdrawalMemberServiceImpl.java
@@ -1,11 +1,18 @@
 package com.ourdressingtable.member.service.impl;
 
+import com.ourdressingtable.common.exception.ErrorCode;
+import com.ourdressingtable.common.exception.OurDressingTableException;
+import com.ourdressingtable.common.util.HashUtil;
 import com.ourdressingtable.member.domain.Member;
 import com.ourdressingtable.member.domain.Status;
 import com.ourdressingtable.member.domain.WithdrawalMember;
 import com.ourdressingtable.member.dto.request.WithdrawalMemberRequest;
 import com.ourdressingtable.member.repository.WithdrawalMemberRepository;
 import com.ourdressingtable.member.service.WithdrawalMemberService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import javax.swing.text.html.Option;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,4 +33,26 @@ public class WithdrawalMemberServiceImpl implements WithdrawalMemberService {
         withdrawalMemberRepository.save(withdrawalMember);
     }
 
+    @Override
+    public void validateWithdrawalMember(String email) {
+        String hashedEmail = HashUtil.hash(email);
+        Optional<WithdrawalMember> withdrawalMember = withdrawalMemberRepository.findByHashedEmail(hashedEmail);
+
+        if (withdrawalMember.isPresent()) {
+            WithdrawalMember member = withdrawalMember.get();
+
+            if(member.isBlock()) {
+                throw new OurDressingTableException(ErrorCode.WITHDRAWN_BLOCK_MEMBER_RESTRICTED);
+            }
+
+            LocalDateTime withdrewAt = member.getWithdrewAt().toLocalDateTime();
+            LocalDateTime availableAt = withdrewAt.plusDays(90);
+            if(withdrewAt.plusDays(90).isAfter(LocalDateTime.now())) {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+                String formattedDate = availableAt.format(formatter);
+                String msg = String.format("탈퇴 후 90일 이내에 재가입이 불가능합니다. 재가입 가능일: %s", formattedDate);
+                throw new OurDressingTableException(ErrorCode.WITHDRAWN_MEMBER_RESTRICTED, msg);
+            }
+        }
+    }
 }

--- a/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
+++ b/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
@@ -23,6 +23,7 @@ import com.ourdressingtable.security.dto.CustomUserDetails;
 import com.ourdressingtable.security.dto.LoginRequest;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 public class TestDataFactory {
 
@@ -84,6 +85,19 @@ public class TestDataFactory {
                 .reason("재가입 예정")
                 .password("{noop}Password123!")
                 .isBlock(false)
+                .build();
+    }
+
+    public static WithdrawalMember testWithdrawalMember(String email, LocalDateTime withdrewAt, boolean isBlock) {
+        return WithdrawalMember.builder()
+                .hashedEmail(HashUtil.hash(email))
+                .maskedEmail(MaskingUtil.maskedEmail(email))
+                .hashedPhone(HashUtil.hash("010-1234-5678"))
+                .maskedPhone(MaskingUtil.maskedPhone("010-1234-5678"))
+                .reason("테스트")
+                .isBlock(isBlock)
+                .withdrewAt(Timestamp.valueOf(withdrewAt))
+                .member(testMember(99L))
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈: 기능명
#8 : 탈퇴회원 재가입 확인

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 탈퇴 회원 재가입 확인 로직 추가
- 회원 가입시 탈퇴 회원 재가입 확인 로직 적용
- 테스트 코드 작성

### 🧪테스트 여부
- [x]  테스트 코드
- [ ]  API 테스트