### PR TITLE
fix: 이메일(id) 찾기 제한 수정. bucket4j 버전 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -67,8 +67,8 @@ dependencies {
 	// rate limiting
 	implementation 'com.bucket4j:bucket4j-core:8.5.0'
 	implementation 'com.bucket4j:bucket4j-redis:8.5.0'
+	implementation 'com.bucket4j:bucket4j_jdk8-redis:8.5.0'
 	implementation 'org.redisson:redisson:3.28.0'
-
 
 }
 

--- a/backend/src/test/java/com/ourdressingtable/auth/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/auth/auth/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ourdressingtable.auth.dto.FindEmailRequest;
 import com.ourdressingtable.common.exception.ErrorCode;
 import com.ourdressingtable.common.exception.OurDressingTableException;
+import com.ourdressingtable.common.security.TestSecurityConfig;
 import com.ourdressingtable.common.util.MaskingUtil;
 import com.ourdressingtable.common.util.TestDataFactory;
 import com.ourdressingtable.member.domain.Member;
@@ -28,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -47,6 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @WebMvcTest(controllers = AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(TestSecurityConfig.class)
 @DisplayName("AUTH API 테스트")
 public class AuthControllerTest {
 

--- a/backend/src/test/java/com/ourdressingtable/common/security/TestSecurityConfig.java
+++ b/backend/src/test/java/com/ourdressingtable/common/security/TestSecurityConfig.java
@@ -1,10 +1,17 @@
 package com.ourdressingtable.common.security;
 
+import com.ourdressingtable.common.interceptor.RateLimitInterceptor;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static reactor.core.publisher.Mono.when;
 
 @TestConfiguration(proxyBeanMethods = false)
 public class TestSecurityConfig {
@@ -13,7 +20,20 @@ public class TestSecurityConfig {
     public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
-                        .anyRequest().permitAll());
+                        .requestMatchers("/api/dressing-tables/mine").authenticated()
+                        .anyRequest().permitAll())
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
         return http.build();
+    }
+
+    @Bean
+    public RateLimitInterceptor rateLimitInterceptor() {
+        RateLimitInterceptor interceptor = mock(RateLimitInterceptor.class);
+        try {
+            doReturn(true).when(interceptor).preHandle(any(), any(), any());
+        } catch (Exception e) {
+            throw new RuntimeException("Mock setup for RateLimitInterceptor failed", e);
+        }
+        return interceptor;
     }
 }

--- a/backend/src/test/java/com/ourdressingtable/dressingTable/controller/DressingTableControllerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/dressingTable/controller/DressingTableControllerTest.java
@@ -3,6 +3,7 @@ package com.ourdressingtable.dressingTable.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ourdressingtable.common.exception.ErrorCode;
 import com.ourdressingtable.common.exception.OurDressingTableException;
+import com.ourdressingtable.common.security.TestSecurityConfig;
 import com.ourdressingtable.common.security.WithCustomUser;
 import com.ourdressingtable.common.util.TestDataFactory;
 import com.ourdressingtable.dressingTable.dto.CreateDressingTableRequest;
@@ -16,9 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -34,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @WebMvcTest(controllers = DressingTableController.class)
 @DisplayName("화장대 Controller 테스트")
+@Import(TestSecurityConfig.class)
 public class DressingTableControllerTest {
 
     @Autowired
@@ -175,7 +179,6 @@ public class DressingTableControllerTest {
         @Test
         public void getAllMyDressingTable_returnMemberError() throws Exception {
             mockMvc.perform(get("/api/dressing-tables/mine")
-                    .with(csrf())
                     .with(anonymous()))
                     .andExpect(status().isUnauthorized());
         }


### PR DESCRIPTION
## #️⃣연관된 이슈: 기능명
#8: 이메일(id) 찾기 

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 이메일 찾기 제한 오류 수정

### 🧪테스트 여부
- [x]  테스트 코드
- [x]  API 테스트

