### PR TITLE
메시지 전송 테스트 추가

### DIFF
--- a/backend/src/test/java/com/ourdressingtable/chat/service/KafkaChatProducerTest.java
+++ b/backend/src/test/java/com/ourdressingtable/chat/service/KafkaChatProducerTest.java
@@ -1,0 +1,40 @@
+package com.ourdressingtable.chat.service;
+
+import com.ourdressingtable.chat.dto.ChatMessageRequest;
+import com.ourdressingtable.common.util.TestDataFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Kafka - 메시지 전송 테스트")
+public class KafkaChatProducerTest {
+
+    @Mock
+    private KafkaTemplate<String , ChatMessageRequest> kafkaTemplate;
+
+    @InjectMocks
+    private KafkaChatProducer kafkaChatProducer;
+
+    @Test
+    public void sendMessage_shouldCallKafkaChatProducer() {
+
+        String topic = "chat-message";
+        ChatMessageRequest chatMessageRequest = TestDataFactory.testChatMessageRequest(1L,1L);
+
+        kafkaChatProducer.sendMessage(topic, chatMessageRequest);
+
+        verify(kafkaTemplate).send(topic,chatMessageRequest);
+
+    }
+
+}

--- a/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
+++ b/backend/src/test/java/com/ourdressingtable/common/util/TestDataFactory.java
@@ -4,7 +4,9 @@ import com.ourdressingtable.auth.dto.FindEmailRequest;
 import com.ourdressingtable.chat.domain.Chat;
 import com.ourdressingtable.chat.domain.ChatRead;
 import com.ourdressingtable.chat.domain.Chatroom;
+import com.ourdressingtable.chat.domain.MessageType;
 import com.ourdressingtable.chat.dto.ChatMemberResponse;
+import com.ourdressingtable.chat.dto.ChatMessageRequest;
 import com.ourdressingtable.chat.dto.ChatroomResponse;
 import com.ourdressingtable.chat.dto.CreateOneToOneChatRequest;
 import com.ourdressingtable.community.comment.domain.Comment;
@@ -349,6 +351,14 @@ public class TestDataFactory {
                 .member(member)
                 .chatroom(chatroom)
                 .lastReadAt(LocalDateTime.now())
+                .build();
+    }
+    public static ChatMessageRequest testChatMessageRequest(Long chatroomId, Long senderId) {
+        return ChatMessageRequest.builder()
+                .senderId(senderId)
+                .chatroomId(chatroomId)
+                .messageType(MessageType.TEXT)
+                .content("안녕!")
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈: 기능명
#71 : 메시지 전송 

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 메시지 전송 controller 테스트 코드
- 메시지 전송 kafka 테스트 코드

### 🧪테스트 여부
- [x]  테스트 코드
- [x]  API 테스트
