### PR TITLE
화장품 등록 기능 수정

### DIFF
--- a/backend/src/main/generated/com/ourdressingtable/communityCategory/domain/QCommunityCategory.java
+++ b/backend/src/main/generated/com/ourdressingtable/communityCategory/domain/QCommunityCategory.java
@@ -15,7 +15,7 @@ import com.querydsl.core.types.Path;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QCommunityCategory extends EntityPathBase<CommunityCategory> {
 
-    private static final long serialVersionUID = -468978674L;
+    private static final long serialVersionUID = -1627163602L;
 
     public static final QCommunityCategory communityCategory = new QCommunityCategory("communityCategory");
 

--- a/backend/src/main/generated/com/ourdressingtable/dressingTable/domain/QDressingTable.java
+++ b/backend/src/main/generated/com/ourdressingtable/dressingTable/domain/QDressingTable.java
@@ -16,7 +16,7 @@ import com.querydsl.core.types.dsl.PathInits;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QDressingTable extends EntityPathBase<DressingTable> {
 
-    private static final long serialVersionUID = -986332658L;
+    private static final long serialVersionUID = 6301166L;
 
     private static final PathInits INITS = PathInits.DIRECT2;
 

--- a/backend/src/main/generated/com/ourdressingtable/memberCosmetic/domain/QMemberCosmetic.java
+++ b/backend/src/main/generated/com/ourdressingtable/memberCosmetic/domain/QMemberCosmetic.java
@@ -16,13 +16,11 @@ import com.querydsl.core.types.dsl.PathInits;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QMemberCosmetic extends EntityPathBase<MemberCosmetic> {
 
-    private static final long serialVersionUID = -623584328L;
+    private static final long serialVersionUID = -261468264L;
 
     private static final PathInits INITS = PathInits.DIRECT2;
 
     public static final QMemberCosmetic memberCosmetic = new QMemberCosmetic("memberCosmetic");
-
-    public final com.ourdressingtable.cosmetic.domain.QCosmetic cosmetic;
 
     public final com.ourdressingtable.dressingtable.domain.QDressingTable dressingTable;
 
@@ -33,6 +31,8 @@ public class QMemberCosmetic extends EntityPathBase<MemberCosmetic> {
     public final StringPath imageUrl = createString("imageUrl");
 
     public final com.ourdressingtable.member.domain.QMember member;
+
+    public final DatePath<java.time.LocalDate> notificationDate = createDate("notificationDate", java.time.LocalDate.class);
 
     public final DatePath<java.time.LocalDate> openDate = createDate("openDate", java.time.LocalDate.class);
 
@@ -62,7 +62,6 @@ public class QMemberCosmetic extends EntityPathBase<MemberCosmetic> {
 
     public QMemberCosmetic(Class<? extends MemberCosmetic> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.cosmetic = inits.isInitialized("cosmetic") ? new com.ourdressingtable.cosmetic.domain.QCosmetic(forProperty("cosmetic"), inits.get("cosmetic")) : null;
         this.dressingTable = inits.isInitialized("dressingTable") ? new com.ourdressingtable.dressingtable.domain.QDressingTable(forProperty("dressingTable"), inits.get("dressingTable")) : null;
         this.member = inits.isInitialized("member") ? new com.ourdressingtable.member.domain.QMember(forProperty("member")) : null;
     }

--- a/backend/src/main/java/com/ourdressingtable/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/ourdressingtable/auth/controller/AuthController.java
@@ -17,6 +17,7 @@ import com.ourdressingtable.auth.email.service.ResetPasswordEmailService;
 import com.ourdressingtable.auth.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "인증", description = "인증 관련 API")
+
 public class AuthController {
 
     private final AuthenticationManager authenticationManager;

--- a/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourdressingtable/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.ourdressingtable.member.dto.request.WithdrawalMemberRequest;
 import com.ourdressingtable.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
+@Tag(name = "회원", description = "회원 관련 API")
+
 public class MemberController {
 
     private final MemberService memberService;

--- a/backend/src/main/java/com/ourdressingtable/memberCosmetic/controller/MemberCosmeticController.java
+++ b/backend/src/main/java/com/ourdressingtable/memberCosmetic/controller/MemberCosmeticController.java
@@ -4,6 +4,7 @@ import com.ourdressingtable.membercosmetic.dto.CreateMemberCosmeticRequest;
 import com.ourdressingtable.membercosmetic.dto.CreateMemberCosmeticResponse;
 import com.ourdressingtable.membercosmetic.service.MemberCosmeticService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,8 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/member-cosmetics")
+@Tag(name = "화장품", description = "화장품 관련 API")
+
 public class MemberCosmeticController {
 
     private final MemberCosmeticService memberCosmeticService;

--- a/backend/src/main/java/com/ourdressingtable/memberCosmetic/service/MemberCosmeticServiceImpl.java
+++ b/backend/src/main/java/com/ourdressingtable/memberCosmetic/service/MemberCosmeticServiceImpl.java
@@ -23,6 +23,7 @@ public class MemberCosmeticServiceImpl implements
     private final MemberService memberService;
 
     @Override
+    @Transactional
     public Long createMemberCosmetic(CreateMemberCosmeticRequest request) {
         Long memberId = SecurityUtil.getCurrentMemberId();
         Member member = memberService.getActiveMemberEntityById(memberId);


### PR DESCRIPTION
## #️⃣연관된 이슈: 기능명
#53: 화장품 등록 기능 수정

### 🔘Part
- [x]  BE
- [ ]  FE

### 📝작업 내용
- 누락된 @Transactional 추가
- 누락된 Swagger Tag 추가(auth, member, member-cosmetic) 
- 
### 🧪테스트 여부
- [ ]  테스트 코드
- [x]  API 테스트

### 🔧 앞으로의 과제
- 화장품 등록 기능 테스트 코드 작성
- 화장품 조회 기능 구현
- 화장품 수정 기능 구현
- 화장품 삭제 기능 구현

